### PR TITLE
Fix display of power, humidity and temperature values

### DIFF
--- a/custom_components/echonetlite/climate.py
+++ b/custom_components/echonetlite/climate.py
@@ -139,9 +139,10 @@ class EchonetClimate(ClimateEntity):
     def target_temperature(self):
         """Return the temperature we try to reach."""
         if ENL_HVAC_SET_TEMP in self._connector._update_data:
-            return self._connector._update_data[ENL_HVAC_SET_TEMP]
-        else:
-            return 'unavailable'
+            temp = self._connector._update_data[ENL_HVAC_SET_TEMP]
+            if temp != -3:
+                return temp
+        return None
 
     @property
     def target_temperature_step(self):

--- a/custom_components/echonetlite/climate.py
+++ b/custom_components/echonetlite/climate.py
@@ -131,7 +131,7 @@ class EchonetClimate(ClimateEntity):
                     return None
                 return self._connector._update_data[ENL_HVAC_ROOM_TEMP]
             else:
-                return 'unavailable'
+                return None
         else:
             return self._connector._update_data[ENL_HVAC_SET_TEMP]
 
@@ -197,7 +197,7 @@ class EchonetClimate(ClimateEntity):
     @property
     def fan_mode(self):
         """Return the fan setting."""
-        return self._connector._update_data[ENL_FANSPEED] if ENL_FANSPEED in self._connector._update_data else "unavailable"
+        return self._connector._update_data[ENL_FANSPEED] if ENL_FANSPEED in self._connector._update_data else None
 
     @property
     def fan_modes(self):
@@ -223,7 +223,7 @@ class EchonetClimate(ClimateEntity):
     @property
     def swing_mode(self):
         """Return the swing mode setting."""
-        return self._connector._update_data[ENL_AIR_VERT] if ENL_AIR_VERT in self._connector._update_data else "unavailable"
+        return self._connector._update_data[ENL_AIR_VERT] if ENL_AIR_VERT in self._connector._update_data else None
 
     async def async_set_swing_mode(self, swing_mode):
         """Set new swing mode."""

--- a/custom_components/echonetlite/const.py
+++ b/custom_components/echonetlite/const.py
@@ -1,5 +1,5 @@
 """Constants for the echonetlite integration."""
-from homeassistant.const import CONF_ICON, CONF_TYPE, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_ENERGY, DEVICE_CLASS_HUMIDITY
+from homeassistant.const import CONF_ICON, CONF_TYPE, DEVICE_CLASS_POWER, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_ENERGY, DEVICE_CLASS_HUMIDITY
 from homeassistant.components.sensor import ATTR_STATE_CLASS, STATE_CLASS_MEASUREMENT, STATE_CLASS_TOTAL_INCREASING
 from pychonet.HomeAirConditioner import (
     ENL_FANSPEED,
@@ -43,7 +43,7 @@ ENL_SENSOR_OP_CODES = {
         0x30: {
             0x84: {
                 CONF_ICON: "mdi:flash",
-                CONF_TYPE: DEVICE_CLASS_ENERGY,
+                CONF_TYPE: DEVICE_CLASS_POWER,
                 CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT
             },
             0x85: {
@@ -70,7 +70,7 @@ ENL_SENSOR_OP_CODES = {
         0x35: {
             0x84: {
                 CONF_ICON: "mdi:flash",
-                CONF_TYPE: DEVICE_CLASS_ENERGY,
+                CONF_TYPE: DEVICE_CLASS_POWER,
                 CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT
             },
             0x85: {

--- a/custom_components/echonetlite/sensor.py
+++ b/custom_components/echonetlite/sensor.py
@@ -144,9 +144,11 @@ class EchonetSensor(SensorEntity):
         """Return the state of the sensor."""
         if self._instance._update_data[self._op_code] is None:
             return STATE_UNAVAILABLE
-        elif self._sensor_attributes[CONF_TYPE] == DEVICE_CLASS_TEMPERATURE:
+        elif self._sensor_attributes[CONF_TYPE] in [
+                DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_HUMIDITY
+        ]:
             if self._op_code in self._instance._update_data:
-                if self._instance._update_data[self._op_code] == 126:
+                if self._instance._update_data[self._op_code] in [126, 253]:
                     return STATE_UNAVAILABLE
                 else:
                     return self._instance._update_data[self._op_code]

--- a/custom_components/echonetlite/sensor.py
+++ b/custom_components/echonetlite/sensor.py
@@ -2,8 +2,8 @@
 import logging
 
 from homeassistant.const import (
-    CONF_ICON, CONF_TYPE,
-    DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_ENERGY,
+    CONF_ICON, CONF_TYPE, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_POWER,
+    DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_ENERGY, PERCENTAGE, POWER_WATT,
     TEMP_CELSIUS, ENERGY_WATT_HOUR,
     STATE_UNAVAILABLE
 )
@@ -105,6 +105,10 @@ class EchonetSensor(SensorEntity):
             self._unit_of_measurement = TEMP_CELSIUS
         elif self._sensor_attributes[CONF_TYPE] == DEVICE_CLASS_ENERGY:
             self._unit_of_measurement = ENERGY_WATT_HOUR
+        elif self._sensor_attributes[CONF_TYPE] == DEVICE_CLASS_POWER:
+            self._unit_of_measurement = POWER_WATT
+        elif self._sensor_attributes[CONF_TYPE] == DEVICE_CLASS_HUMIDITY:
+            self._unit_of_measurement = PERCENTAGE
         else:
             self._unit_of_measurement = None
 
@@ -144,6 +148,15 @@ class EchonetSensor(SensorEntity):
             if self._op_code in self._instance._update_data:
                 if self._instance._update_data[self._op_code] == 126:
                     return STATE_UNAVAILABLE
+                else:
+                    return self._instance._update_data[self._op_code]
+            else:
+                return STATE_UNAVAILABLE
+        elif self._sensor_attributes[CONF_TYPE] == DEVICE_CLASS_POWER:
+            if self._op_code in self._instance._update_data:
+                # Underflow (less than 1 W)
+                if self._instance._update_data[self._op_code] == 65534:
+                    return 1
                 else:
                     return self._instance._update_data[self._op_code]
             else:


### PR DESCRIPTION
Correct the unit of instant power consumption to watts, humidity to %
and handle the underflow special value for power consumption so that
values lower than 1W are displayed as 1W rather than 65534W.