### PR TITLE
Auto configure of the power switch

### DIFF
--- a/custom_components/echonetlite/const.py
+++ b/custom_components/echonetlite/const.py
@@ -26,6 +26,11 @@ from pychonet.HomeAirConditioner import (
     AUTO_DIRECTION,
     SWING_MODE
 )
+from pychonet.EchonetInstance import (
+    ENL_STATUS,
+    ENL_ON,
+    ENL_OFF
+)
 
 DOMAIN = "echonetlite"
 CONF_STATE_CLASS = ATTR_STATE_CLASS
@@ -35,8 +40,8 @@ DATA_STATE_OFF = "Off"
 TYPE_SWITCH = "switch"
 SERVICE_SET_ON_TIMER_TIME = "set_on_timer_time"
 SWITCH_POWER = {
-    DATA_STATE_ON: 0x30,
-    DATA_STATE_OFF: 0x31
+    DATA_STATE_ON: ENL_ON,
+    DATA_STATE_OFF: ENL_OFF
 }
 SWITCH_BINARY = {
     DATA_STATE_ON: 0x41,
@@ -108,27 +113,22 @@ ENL_OP_CODES = {
     },
     0x02: {
         0x72: {
-            0x80: { # switch
-                CONF_ICON: "mdi:power-settings",
-                CONF_SERVICE_DATA: SWITCH_POWER,
-                TYPE_SWITCH: True
-            },
             0x90: {
                 CONF_ICON: "mdi:timer",
                 CONF_SERVICE_DATA: SWITCH_BINARY,
-                CONF_ENSURE_ON: 0x80,
+                CONF_ENSURE_ON: ENL_STATUS,
                 TYPE_SWITCH: True
             },
             0xE3: {
                 CONF_ICON: "mdi:bathtub-outline",
                 CONF_SERVICE_DATA: SWITCH_BINARY,
-                CONF_ENSURE_ON: 0x80,
+                CONF_ENSURE_ON: ENL_STATUS,
                 TYPE_SWITCH: True
             },
             0xE4: {
                 CONF_ICON: "mdi:heat-wave",
                 CONF_SERVICE_DATA: SWITCH_BINARY,
-                CONF_ENSURE_ON: 0x80,
+                CONF_ENSURE_ON: ENL_STATUS,
                 TYPE_SWITCH: True
             },
             0x91: { # Sensor with service

--- a/custom_components/echonetlite/sensor.py
+++ b/custom_components/echonetlite/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.typing import StateType
 
 from pychonet.lib.epc import EPC_CODE, EPC_SUPER
 from pychonet.lib.eojx import EOJX_CLASS
-from .const import DOMAIN, ENL_OP_CODES, CONF_STATE_CLASS, TYPE_SWITCH, SERVICE_SET_ON_TIMER_TIME
+from .const import DOMAIN, ENL_OP_CODES, CONF_STATE_CLASS, TYPE_SWITCH, SERVICE_SET_ON_TIMER_TIME, ENL_STATUS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +27,7 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
         _LOGGER.debug(f"Update flags for this sensor are {entity['echonetlite']._update_flags_full_list}")
         eojgc = entity['instance']['eojgc']
         eojcc = entity['instance']['eojcc']
+        power_switch = ENL_STATUS in entity['instance']['setmap']
 
         # Home Air Conditioner we dont bother exposing all sensors
         if eojgc == 1 and eojcc == 48:
@@ -68,7 +69,7 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
                                             "async_" + service_name
                                         )
 
-                            if TYPE_SWITCH in _keys:
+                            if TYPE_SWITCH in _keys or (power_switch and ENL_STATUS == op_code):
                                 continue # dont configure as sensor, it will be configured as switch instead.
 
                             entities.append(


### PR DESCRIPTION
To fixes #84.

After checking the ECHONET specifications, it seems that 0x80 is defined by the super class and can be set on many devices. So, I send PR to implement automatic configuer of the power switch.