### PR TITLE
Use property map for immediate notification when status changes

### DIFF
--- a/custom_components/echonetlite/__init__.py
+++ b/custom_components/echonetlite/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import pychonet as echonet
 from pychonet.lib.epc import EPC_SUPER, EPC_CODE
-from pychonet.lib.const import VERSION
+from pychonet.lib.const import VERSION, ENL_STATMAP
 from datetime import timedelta
 import asyncio
 from homeassistant.config_entries import ConfigEntry
@@ -93,11 +93,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
     for instance in entry.data["instances"]:
+        # auto update to new style
+        if "ntfmap" not in instance:
+            instance["ntfmap"] = []
         echonetlite = None
         host = instance["host"]
         eojgc = instance["eojgc"]
         eojcc = instance["eojcc"]
         eojci = instance["eojci"]
+        ntfmap = instance["ntfmap"]
         getmap = instance["getmap"]
         setmap = instance["setmap"]
         uid = instance["uid"]
@@ -109,6 +113,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     eojgc: {
                         eojcc: {
                             eojci: {
+                                ENL_STATMAP: ntfmap,
                                 ENL_SETMAP: setmap,
                                 ENL_GETMAP: getmap,
                                 ENL_UID: uid
@@ -122,6 +127,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 eojgc: {
                     eojcc: {
                         eojci: {
+                            ENL_STATMAP: ntfmap,
                             ENL_SETMAP: setmap,
                             ENL_GETMAP: getmap,
                             ENL_UID: uid
@@ -133,6 +139,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             server._state[host]["instances"][eojgc].update({
                 eojcc: {
                     eojci: {
+                        ENL_STATMAP: ntfmap,
                         ENL_SETMAP: setmap,
                         ENL_GETMAP: getmap,
                         ENL_UID: uid
@@ -142,6 +149,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if eojci not in list(server._state[host]["instances"][eojgc][eojcc]):
             server._state[host]["instances"][eojgc][eojcc].update({
                 eojci: {
+                    ENL_STATMAP: ntfmap,
                     ENL_SETMAP: setmap,
                     ENL_GETMAP: getmap,
                     ENL_UID: uid
@@ -194,6 +202,7 @@ class ECHONETConnector():
         self._update_data = {}
         self._api = api
         self._update_callbacks = []
+        self._ntfPropertyMap = self._api._state[self._host]["instances"][self._eojgc][self._eojcc][self._eojci][ENL_STATMAP]
         self._getPropertyMap = self._api._state[self._host]["instances"][self._eojgc][self._eojcc][self._eojci][ENL_GETMAP]
         self._setPropertyMap = self._api._state[self._host]["instances"][self._eojgc][self._eojcc][self._eojci][ENL_SETMAP]
         self._manufacturer = None

--- a/custom_components/echonetlite/__init__.py
+++ b/custom_components/echonetlite/__init__.py
@@ -193,6 +193,9 @@ async def update_listener(hass, entry):
             if entry.options.get(key) is not None or option.get('default'):
                 instance["echonetlite"]._user_options.update({key: entry.options.get(key, option.get('default'))})
 
+        for func in instance["echonetlite"]._update_option_func:
+            func()
+
 class ECHONETConnector():
     """EchonetAPIConnector is used to centralise API calls for  Echonet devices.
     API calls are aggregated per instance (not per node!)"""

--- a/custom_components/echonetlite/__init__.py
+++ b/custom_components/echonetlite/__init__.py
@@ -189,9 +189,9 @@ async def update_listener(hass, entry):
                 if entry.options.get(option) is not None:
                     instance["echonetlite"]._user_options.update({option: entry.options.get(option)})
 
-        for key in MISC_OPTIONS:
-            if entry.options.get(key) is not None:
-                instance["echonetlite"]._user_options.update({key: entry.options.get(key)})
+        for key, option in MISC_OPTIONS.items():
+            if entry.options.get(key) is not None or option.get('default'):
+                instance["echonetlite"]._user_options.update({key: entry.options.get(key, option.get('default'))})
 
 class ECHONETConnector():
     """EchonetAPIConnector is used to centralise API calls for  Echonet devices.
@@ -206,6 +206,7 @@ class ECHONETConnector():
         self._update_data = {}
         self._api = api
         self._update_callbacks = []
+        self._update_option_func = []
         self._ntfPropertyMap = self._api._state[self._host]["instances"][self._eojgc][self._eojcc][self._eojci][ENL_STATMAP]
         self._getPropertyMap = self._api._state[self._host]["instances"][self._eojgc][self._eojcc][self._eojci][ENL_GETMAP]
         self._setPropertyMap = self._api._state[self._host]["instances"][self._eojgc][self._eojcc][self._eojci][ENL_SETMAP]
@@ -319,3 +320,6 @@ class ECHONETConnector():
 
     def register_async_update_callbacks(self, update_func):
         self._update_callbacks.append(update_func)
+
+    def add_update_option_listener(self, update_func):
+        self._update_option_func.append(update_func)

--- a/custom_components/echonetlite/__init__.py
+++ b/custom_components/echonetlite/__init__.py
@@ -9,7 +9,7 @@ import asyncio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.util import Throttle
-from .const import DOMAIN, USER_OPTIONS, TEMP_OPTIONS
+from .const import DOMAIN, USER_OPTIONS, TEMP_OPTIONS, CONF_FORCE_POLLING, MISC_OPTIONS
 from pychonet.lib.udpserver import UDPServer
 
 from pychonet import ECHONETAPIClient
@@ -187,7 +187,11 @@ async def update_listener(hass, entry):
                         instance["echonetlite"]._user_options.update({option: False})
             for option in TEMP_OPTIONS.keys():
                 if entry.options.get(option) is not None:
-                        instance["echonetlite"]._user_options.update({option: entry.options.get(option)})
+                    instance["echonetlite"]._user_options.update({option: entry.options.get(option)})
+
+        for key in MISC_OPTIONS:
+            if entry.options.get(key) is not None:
+                instance["echonetlite"]._user_options.update({key: entry.options.get(key)})
 
 class ECHONETConnector():
     """EchonetAPIConnector is used to centralise API calls for  Echonet devices.

--- a/custom_components/echonetlite/config_flow.py
+++ b/custom_components/echonetlite/config_flow.py
@@ -17,7 +17,7 @@ from pychonet.lib.const import ENL_STATMAP, ENL_SETMAP, ENL_GETMAP, ENL_UID, ENL
 from pychonet.lib.udpserver import UDPServer
 # from pychonet import Factory
 from pychonet import ECHONETAPIClient
-from .const import DOMAIN, USER_OPTIONS, TEMP_OPTIONS, CONF_FORCE_POLLING
+from .const import DOMAIN, USER_OPTIONS, TEMP_OPTIONS, CONF_FORCE_POLLING, MISC_OPTIONS
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -205,12 +205,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """Manage the options."""
         data_schema_structure = {}
 
-        data_schema_structure.update({
-            vol.Required(
-                CONF_FORCE_POLLING,
-                default=self._config_entry.options.get(CONF_FORCE_POLLING, False) 
-            ): bool
-        })
+        for key, option in MISC_OPTIONS.items():
+            data_schema_structure.update({
+                vol.Required(
+                    CONF_FORCE_POLLING,
+                    default=self._config_entry.options.get(key, option['default']) 
+                ): option['type']
+            })
 
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/custom_components/echonetlite/config_flow.py
+++ b/custom_components/echonetlite/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
-from pychonet.lib.const import ENL_SETMAP, ENL_GETMAP, ENL_UID, ENL_MANUFACTURER
+from pychonet.lib.const import ENL_STATMAP, ENL_SETMAP, ENL_GETMAP, ENL_UID, ENL_MANUFACTURER
 #from aioudp import UDPServer
 from pychonet.lib.udpserver import UDPServer
 # from pychonet import Factory
@@ -67,6 +67,7 @@ async def validate_input(hass: HomeAssistant,  user_input: dict[str, Any]) -> di
 
                 await server.getAllPropertyMaps(host, eojgc, eojcc, instance)
                 _LOGGER.debug(f"{host} - ECHONET Instance {eojgc}-{eojcc}-{instance} map attributes discovered!")
+                ntfmap = state['instances'][eojgc][eojcc][instance][ENL_STATMAP]
                 getmap = state['instances'][eojgc][eojcc][instance][ENL_GETMAP]
                 setmap = state['instances'][eojgc][eojcc][instance][ENL_SETMAP]
 
@@ -88,6 +89,7 @@ async def validate_input(hass: HomeAssistant,  user_input: dict[str, Any]) -> di
                     "eojgc": eojgc,
                     "eojcc": eojcc,
                     "eojci": instance,
+                    "ntfmap": ntfmap,
                     "getmap": getmap,
                     "setmap": setmap,
                     "uid": uid,

--- a/custom_components/echonetlite/config_flow.py
+++ b/custom_components/echonetlite/config_flow.py
@@ -196,7 +196,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         })
 
         if user_input is not None or not any(data_schema_structure):
-            self._data.update(user_input)
+            if user_input is not None:
+                self._data.update(user_input)
             return await self.async_step_misc()
         return self.async_show_form(
             step_id="init",

--- a/custom_components/echonetlite/config_flow.py
+++ b/custom_components/echonetlite/config_flow.py
@@ -145,6 +145,7 @@ class CannotConnect(HomeAssistantError):
 class OptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config):
         self._config_entry = config
+        self._data = {}
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""
@@ -195,6 +196,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         })
 
         if user_input is not None or not any(data_schema_structure):
+            self._data.update(user_input)
             return await self.async_step_misc()
         return self.async_show_form(
             step_id="init",
@@ -214,7 +216,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             })
 
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            self._data.update(user_input)
+            return self.async_create_entry(title="", data=self._data)
         return self.async_show_form(
             step_id="misc",
             data_schema=vol.Schema(data_schema_structure),

--- a/custom_components/echonetlite/config_flow.py
+++ b/custom_components/echonetlite/config_flow.py
@@ -67,7 +67,7 @@ async def validate_input(hass: HomeAssistant,  user_input: dict[str, Any]) -> di
 
                 await server.getAllPropertyMaps(host, eojgc, eojcc, instance)
                 _LOGGER.debug(f"{host} - ECHONET Instance {eojgc}-{eojcc}-{instance} map attributes discovered!")
-                ntfmap = state['instances'][eojgc][eojcc][instance][ENL_STATMAP]
+                ntfmap = state['instances'][eojgc][eojcc][instance].get(ENL_STATMAP, [])
                 getmap = state['instances'][eojgc][eojcc][instance][ENL_GETMAP]
                 setmap = state['instances'][eojgc][eojcc][instance][ENL_SETMAP]
 

--- a/custom_components/echonetlite/config_flow.py
+++ b/custom_components/echonetlite/config_flow.py
@@ -17,7 +17,7 @@ from pychonet.lib.const import ENL_STATMAP, ENL_SETMAP, ENL_GETMAP, ENL_UID, ENL
 from pychonet.lib.udpserver import UDPServer
 # from pychonet import Factory
 from pychonet import ECHONETAPIClient
-from .const import DOMAIN, USER_OPTIONS, TEMP_OPTIONS
+from .const import DOMAIN, USER_OPTIONS, TEMP_OPTIONS, CONF_FORCE_POLLING
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -194,9 +194,27 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             )
                         })
 
+        if user_input is not None or not any(data_schema_structure):
+            return await self.async_step_misc()
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(data_schema_structure),
+        )
+
+    async def async_step_misc(self, user_input=None):
+        """Manage the options."""
+        data_schema_structure = {}
+
+        data_schema_structure.update({
+            vol.Required(
+                CONF_FORCE_POLLING,
+                default=self._config_entry.options.get(CONF_FORCE_POLLING, False) 
+            ): bool
+        })
+
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
         return self.async_show_form(
-            step_id="init",
+            step_id="misc",
             data_schema=vol.Schema(data_schema_structure),
         )

--- a/custom_components/echonetlite/const.py
+++ b/custom_components/echonetlite/const.py
@@ -35,6 +35,7 @@ from pychonet.EchonetInstance import (
 DOMAIN = "echonetlite"
 CONF_STATE_CLASS = ATTR_STATE_CLASS
 CONF_ENSURE_ON = "ensureon"
+CONF_FORCE_POLLING = 'force_polling'
 DATA_STATE_ON = "On"
 DATA_STATE_OFF = "Off"
 TYPE_SWITCH = "switch"

--- a/custom_components/echonetlite/const.py
+++ b/custom_components/echonetlite/const.py
@@ -335,3 +335,10 @@ TEMP_OPTIONS = {"min_temp_heat": {"min":10, "max":25},
                 "min_temp_auto": {"min":15, "max":25},
                 "max_temp_auto": {"min":18, "max":30},
 }
+
+MISC_OPTIONS = {
+    CONF_FORCE_POLLING: {
+        'type': bool,
+        'default': False
+    }
+}

--- a/custom_components/echonetlite/fan.py
+++ b/custom_components/echonetlite/fan.py
@@ -128,8 +128,6 @@ class EchonetFan(FanEntity):
         self._connector._update_data[ENL_FANSPEED] = preset_mode
 
     async def async_update_callback(self, isPush = False):
-        if isPush and self._should_poll:
-            self._should_poll = False
         changed = self._olddata != self._connector._update_data
         if (changed):
             self._olddata = self._connector._update_data.copy()

--- a/custom_components/echonetlite/light.py
+++ b/custom_components/echonetlite/light.py
@@ -198,8 +198,6 @@ class EchonetLight(LightEntity):
         return self._supported_color_modes
 
     async def async_update_callback(self, isPush = False):
-        if isPush and self._should_poll:
-            self._should_poll = False
         changed = self._olddata != self._connector._update_data
         if (changed):
             self._olddata = self._connector._update_data.copy()

--- a/custom_components/echonetlite/select.py
+++ b/custom_components/echonetlite/select.py
@@ -76,9 +76,8 @@ class EchonetSelect(SelectEntity):
         self._attr_name = f"{config.title} {EPC_CODE[self._connector._eojgc][self._connector._eojcc][self._code]}"
         self._uid = f'{self._connector._uid}-{self._code}'
         self._device_name = name
-        self._olddata = {}
-        self._should_poll = True
-        self._connector.register_async_update_callbacks(self.async_update_callback)
+        self._should_poll = self._code not in self._connector._ntfPropertyMap
+        _LOGGER.debug(f"{self._device_name}({self._code}): _should_poll is {self._should_poll}")
 
     @property
     def unique_id(self):
@@ -118,10 +117,7 @@ class EchonetSelect(SelectEntity):
                 self._attr_options = self._connector._user_options[self._code]
 
     async def async_update_callback(self, isPush = False):
-        if isPush and self._should_poll:
-            self._should_poll = False
-        changed = self._olddata != self._connector._update_data
+        changed = self._attr_current_option != self._connector._update_data[self._code]
         if (changed):
-            self._olddata = self._connector._update_data.copy()
             self.update_attr()
             self.async_schedule_update_ha_state()

--- a/custom_components/echonetlite/select.py
+++ b/custom_components/echonetlite/select.py
@@ -1,6 +1,6 @@
 import logging
 from homeassistant.components.select import SelectEntity
-from .const import HVAC_SELECT_OP_CODES, DOMAIN, FAN_SELECT_OP_CODES, COVER_SELECT_OP_CODES
+from .const import HVAC_SELECT_OP_CODES, DOMAIN, FAN_SELECT_OP_CODES, COVER_SELECT_OP_CODES, CONF_FORCE_POLLING
 from pychonet.lib.epc import EPC_CODE
 from pychonet.lib.eojx import EOJX_CLASS
 
@@ -76,7 +76,7 @@ class EchonetSelect(SelectEntity):
         self._attr_name = f"{config.title} {EPC_CODE[self._connector._eojgc][self._connector._eojcc][self._code]}"
         self._uid = f'{self._connector._uid}-{self._code}'
         self._device_name = name
-        self._should_poll = self._code not in self._connector._ntfPropertyMap
+        self._should_poll = self._connector._user_options.get(CONF_FORCE_POLLING, False) or self._code not in self._connector._ntfPropertyMap
         _LOGGER.debug(f"{self._device_name}({self._code}): _should_poll is {self._should_poll}")
 
     @property

--- a/custom_components/echonetlite/select.py
+++ b/custom_components/echonetlite/select.py
@@ -76,8 +76,10 @@ class EchonetSelect(SelectEntity):
         self._attr_name = f"{config.title} {EPC_CODE[self._connector._eojgc][self._connector._eojcc][self._code]}"
         self._uid = f'{self._connector._uid}-{self._code}'
         self._device_name = name
-        self._should_poll = self._connector._user_options.get(CONF_FORCE_POLLING, False) or self._code not in self._connector._ntfPropertyMap
-        _LOGGER.debug(f"{self._device_name}({self._code}): _should_poll is {self._should_poll}")
+        self._should_poll = True
+        self.update_option_listener()
+        self._connector.add_update_option_listener(self.update_option_listener)
+        self._connector.register_async_update_callbacks(self.async_update_callback)
 
     @property
     def unique_id(self):
@@ -127,3 +129,7 @@ class EchonetSelect(SelectEntity):
         if (changed):
             self.update_attr()
             self.async_schedule_update_ha_state()
+
+    def update_option_listener(self):
+        self._should_poll = self._connector._user_options.get(CONF_FORCE_POLLING, False) or self._code not in self._connector._ntfPropertyMap
+        _LOGGER.info(f"{self._device_name}({self._code}): _should_poll is {self._should_poll}")

--- a/custom_components/echonetlite/select.py
+++ b/custom_components/echonetlite/select.py
@@ -102,6 +102,7 @@ class EchonetSelect(SelectEntity):
 
     async def async_select_option(self, option: str):
         await self._connector._instance.setMessage(self._code, self._options[option])
+        self._connector._update_data[self._code] = option
         self._attr_current_option = option
 
     async def async_update(self):
@@ -112,6 +113,11 @@ class EchonetSelect(SelectEntity):
     def update_attr(self):
         self._attr_current_option = self._connector._update_data[self._code]
         self._attr_options = list(self._options.keys())
+        if self._attr_current_option not in self._attr_options:
+            # maybe data value is raw(int)
+            keys = [k for k, v in self._options.items() if v == self._attr_current_option]
+            if keys:
+                self._attr_current_option = keys[0]
         if self._code in list(self._connector._user_options.keys()):
             if self._connector._user_options[self._code] is not False:
                 self._attr_options = self._connector._user_options[self._code]

--- a/custom_components/echonetlite/sensor.py
+++ b/custom_components/echonetlite/sensor.py
@@ -104,9 +104,10 @@ class EchonetSensor(SensorEntity):
         self._eojci = self._instance._eojci
         self._uid = f'{self._instance._host}-{self._eojgc}-{self._eojcc}-{self._eojci}-{self._op_code}'
         self._device_name = name
-        self._should_poll = True
+        self._should_poll = self._op_code not in self._instance._ntfPropertyMap
         self._state_value = None
         self._instance.register_async_update_callbacks(self.async_update_callback)
+        _LOGGER.debug(f"{self._name}({self._op_code}): _should_poll is {self._should_poll}")
 
         _attr_keys = self._sensor_attributes.keys()
         if CONF_ICON not in _attr_keys:
@@ -256,8 +257,6 @@ class EchonetSensor(SensorEntity):
             self.async_write_ha_state()
 
     async def async_update_callback(self, isPush = False):
-        if isPush and self._should_poll:
-            self._should_poll = False
         changed = self._state_value != self._instance._update_data[self._op_code]
         if (changed):
             self._state_value = self._instance._update_data[self._op_code]

--- a/custom_components/echonetlite/sensor.py
+++ b/custom_components/echonetlite/sensor.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.typing import StateType
 from pychonet.lib.epc import EPC_CODE, EPC_SUPER
 from pychonet.lib.eojx import EOJX_CLASS
 from pychonet.ElectricBlind import ENL_OPENSTATE
-from .const import DOMAIN, ENL_OP_CODES, CONF_STATE_CLASS, TYPE_SWITCH, SERVICE_SET_ON_TIMER_TIME, ENL_STATUS
+from .const import DOMAIN, ENL_OP_CODES, CONF_STATE_CLASS, TYPE_SWITCH, SERVICE_SET_ON_TIMER_TIME, ENL_STATUS, CONF_FORCE_POLLING
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ class EchonetSensor(SensorEntity):
         self._eojci = self._instance._eojci
         self._uid = f'{self._instance._host}-{self._eojgc}-{self._eojcc}-{self._eojci}-{self._op_code}'
         self._device_name = name
-        self._should_poll = self._op_code not in self._instance._ntfPropertyMap
+        self._should_poll = self._instance._user_options.get(CONF_FORCE_POLLING, False) or self._op_code not in self._instance._ntfPropertyMap
         self._state_value = None
 
         _attr_keys = self._sensor_attributes.keys()

--- a/custom_components/echonetlite/sensor.py
+++ b/custom_components/echonetlite/sensor.py
@@ -104,7 +104,7 @@ class EchonetSensor(SensorEntity):
         self._eojci = self._instance._eojci
         self._uid = f'{self._instance._host}-{self._eojgc}-{self._eojcc}-{self._eojci}-{self._op_code}'
         self._device_name = name
-        self._should_poll = self._instance._user_options.get(CONF_FORCE_POLLING, False) or self._op_code not in self._instance._ntfPropertyMap
+        self._should_poll = True
         self._state_value = None
 
         _attr_keys = self._sensor_attributes.keys()
@@ -143,8 +143,9 @@ class EchonetSensor(SensorEntity):
             else:
                 self._unit_of_measurement = None
 
+        self.update_option_listener()
+        self._instance.add_update_option_listener(self.update_option_listener)
         self._instance.register_async_update_callbacks(self.async_update_callback)
-        _LOGGER.debug(f"{self._name}({self._op_code}): _should_poll is {self._should_poll}")
 
     @property
     def icon(self):
@@ -262,3 +263,7 @@ class EchonetSensor(SensorEntity):
         if (changed):
             self._state_value = self._instance._update_data[self._op_code]
             self.async_schedule_update_ha_state()
+
+    def update_option_listener(self):
+        self._should_poll = self._instance._user_options.get(CONF_FORCE_POLLING, False) or self._op_code not in self._instance._ntfPropertyMap
+        _LOGGER.info(f"{self._name}({self._op_code}): _should_poll is {self._should_poll}")

--- a/custom_components/echonetlite/sensor.py
+++ b/custom_components/echonetlite/sensor.py
@@ -106,8 +106,6 @@ class EchonetSensor(SensorEntity):
         self._device_name = name
         self._should_poll = self._op_code not in self._instance._ntfPropertyMap
         self._state_value = None
-        self._instance.register_async_update_callbacks(self.async_update_callback)
-        _LOGGER.debug(f"{self._name}({self._op_code}): _should_poll is {self._should_poll}")
 
         _attr_keys = self._sensor_attributes.keys()
         if CONF_ICON not in _attr_keys:
@@ -144,6 +142,9 @@ class EchonetSensor(SensorEntity):
                 self._unit_of_measurement = self._sensor_attributes[CONF_UNIT_OF_MEASUREMENT]
             else:
                 self._unit_of_measurement = None
+
+        self._instance.register_async_update_callbacks(self.async_update_callback)
+        _LOGGER.debug(f"{self._name}({self._op_code}): _should_poll is {self._should_poll}")
 
     @property
     def icon(self):

--- a/custom_components/echonetlite/switch.py
+++ b/custom_components/echonetlite/switch.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from homeassistant.const import CONF_ICON, CONF_SERVICE_DATA
 from homeassistant.components.switch import SwitchEntity
-from .const import DOMAIN, ENL_OP_CODES, DATA_STATE_ON, DATA_STATE_OFF, SWITCH_POWER, CONF_ENSURE_ON, TYPE_SWITCH, ENL_STATUS, ENL_ON, ENL_OFF
+from .const import DOMAIN, ENL_OP_CODES, DATA_STATE_ON, DATA_STATE_OFF, SWITCH_POWER, CONF_ENSURE_ON, TYPE_SWITCH, ENL_STATUS, ENL_ON, ENL_OFF, CONF_FORCE_POLLING
 from pychonet.lib.epc import EPC_CODE
 from pychonet.lib.eojx import EOJX_CLASS
 from pychonet.lib.const import ENL_SETMAP
@@ -65,7 +65,7 @@ class EchonetSwitch(SwitchEntity):
         self._attr_icon = options[CONF_ICON]
         self._uid = f'{self._connector._uid}-{self._code}'
         self._device_name = name
-        self._should_poll = self._code not in self._connector._ntfPropertyMap
+        self._should_poll = self._connector._user_options.get(CONF_FORCE_POLLING, False) or self._code not in self._connector._ntfPropertyMap
         self._connector.register_async_update_callbacks(self.async_update_callback)
         _LOGGER.debug(f"{self._device_name}({self._code}): _should_poll is {self._should_poll}")
 

--- a/custom_components/echonetlite/switch.py
+++ b/custom_components/echonetlite/switch.py
@@ -65,9 +65,10 @@ class EchonetSwitch(SwitchEntity):
         self._attr_icon = options[CONF_ICON]
         self._uid = f'{self._connector._uid}-{self._code}'
         self._device_name = name
-        self._should_poll = self._connector._user_options.get(CONF_FORCE_POLLING, False) or self._code not in self._connector._ntfPropertyMap
+        self._should_poll = True
+        self.update_option_listener()
+        self._connector.add_update_option_listener(self.update_option_listener)
         self._connector.register_async_update_callbacks(self.async_update_callback)
-        _LOGGER.debug(f"{self._device_name}({self._code}): _should_poll is {self._should_poll}")
 
     @property
     def unique_id(self):
@@ -135,3 +136,7 @@ class EchonetSwitch(SwitchEntity):
         if (self._attr_is_on != _is_on):
             self._attr_is_on = _is_on
             self.async_schedule_update_ha_state()
+
+    def update_option_listener(self):
+        self._should_poll = self._connector._user_options.get(CONF_FORCE_POLLING, False) or self._code not in self._connector._ntfPropertyMap
+        _LOGGER.info(f"{self._device_name}({self._code}): _should_poll is {self._should_poll}")

--- a/custom_components/echonetlite/switch.py
+++ b/custom_components/echonetlite/switch.py
@@ -65,8 +65,9 @@ class EchonetSwitch(SwitchEntity):
         self._attr_icon = options[CONF_ICON]
         self._uid = f'{self._connector._uid}-{self._code}'
         self._device_name = name
-        self._should_poll = True
+        self._should_poll = self._code not in self._connector._ntfPropertyMap
         self._connector.register_async_update_callbacks(self.async_update_callback)
+        _LOGGER.debug(f"{self._device_name}({self._code}): _should_poll is {self._should_poll}")
 
     @property
     def unique_id(self):
@@ -130,8 +131,6 @@ class EchonetSwitch(SwitchEntity):
         self._attr_is_on = self._connector._update_data[self._code] == DATA_STATE_ON
 
     async def async_update_callback(self, isPush = False):
-        if isPush and self._should_poll:
-            self._should_poll = False
         _is_on = self._connector._update_data[self._code] == DATA_STATE_ON
         if (self._attr_is_on != _is_on):
             self._attr_is_on = _is_on

--- a/custom_components/echonetlite/translations/en.json
+++ b/custom_components/echonetlite/translations/en.json
@@ -41,8 +41,15 @@
                    "max_temp_auto": "Configure Maximum Temperature for Automatic Operation"
                 },
                 "description": "Configure optional fan and swing mode settings"
-                }
+            },
+            "misc": {
+                "title": "ECHONET Lite misc options",
+                "data": {
+                   "force_polling": "Do not stop polling even if immediate notification is expected."
+                },
+                "description": "Setting various options"
             }
-        },
+        }
+    },
     "title": "ECHONETLite"
 }

--- a/custom_components/echonetlite/translations/ja.json
+++ b/custom_components/echonetlite/translations/ja.json
@@ -41,8 +41,15 @@
                    "max_temp_auto": "自動モード時の最高温度設定"
                 },
                 "description": "風向とスイングモードなどのオプション設定を構成する"
-                }
+            },
+            "misc": {
+                "title": "ECHONET Lite その他のオプション",
+                "data": {
+                   "force_polling": "即時通知が見込める場合でもポーリングを止めない。"
+                },
+                "description": "各種のオプションの設定"
             }
-        },
+        }
+    },
     "title": "ECHONETLite"
 }


### PR DESCRIPTION
Immediate notification on status changes does not notify all properties, only those shown in the property map (ENL_STATMAP).
Performs polling control according to its properties.
Also, climate, fan, and light do not stop polling for the time being.
If we implement it seriously, we need to find out which properties we use and compare them with ENL_STATMAP.