### PR TITLE
Handling of air conditioner operation mode "other"

### DIFF
--- a/custom_components/echonetlite/__init__.py
+++ b/custom_components/echonetlite/__init__.py
@@ -173,10 +173,13 @@ async def update_listener(hass, entry):
         if instance['instance']['eojgc'] == 1 and instance['instance']['eojcc'] == 48:
             for option in USER_OPTIONS.keys():
                 if entry.options.get(USER_OPTIONS[option]["option"]) is not None:  # check if options has been created
-                    if len(entry.options.get(USER_OPTIONS[option]["option"])) > 0:  # if it has been created then check list length.
-                        instance["echonetlite"]._user_options.update({option: entry.options.get(USER_OPTIONS[option]["option"])})
+                    if isinstance(entry.options.get(USER_OPTIONS[option]["option"]), list):
+                        if len(entry.options.get(USER_OPTIONS[option]["option"])) > 0:  # if it has been created then check list length.
+                            instance["echonetlite"]._user_options.update({option: entry.options.get(USER_OPTIONS[option]["option"])})
+                        else:
+                            instance["echonetlite"]._user_options.update({option: False})
                     else:
-                        instance["echonetlite"]._user_options.update({option: False})
+                        instance["echonetlite"]._user_options.update({option: entry.options.get(USER_OPTIONS[option]["option"])})
             for option in TEMP_OPTIONS.keys():
                 if entry.options.get(option) is not None:
                         instance["echonetlite"]._user_options.update({option: entry.options.get(option)})

--- a/custom_components/echonetlite/climate.py
+++ b/custom_components/echonetlite/climate.py
@@ -37,7 +37,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     PRECISION_WHOLE,
 )
-from .const import DOMAIN, SILENT_MODE_OPTIONS, CONF_OTHER_MODE
+from .const import DOMAIN, SILENT_MODE_OPTIONS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -170,13 +170,14 @@ class EchonetClimate(ClimateEntity):
             if mode == "auto":
                 mode = HVAC_MODE_HEAT_COOL
             elif mode == "other":
-                if (self._connector._user_options.get(CONF_OTHER_MODE) == "as_idle"):
+                if (self._connector._user_options.get(ENL_HVAC_MODE) == "as_idle"):
                     mode = self._last_mode
                 else:
                     mode = HVAC_MODE_OFF
+            if mode != "other" and mode != HVAC_MODE_OFF:
+                self._last_mode = mode
         else:
             mode = HVAC_MODE_OFF
-        self._last_mode = mode
         return mode
 
     @property
@@ -201,7 +202,7 @@ class EchonetClimate(ClimateEntity):
                             return CURRENT_HVAC_HEAT
                 return CURRENT_HVAC_IDLE
             elif self._connector._update_data[ENL_HVAC_MODE] == "other":
-                if (self._connector._user_options.get(CONF_OTHER_MODE) == "as_idle"):
+                if (self._connector._user_options.get(ENL_HVAC_MODE) == "as_idle"):
                     return CURRENT_HVAC_IDLE
                 else:
                     return CURRENT_HVAC_OFF

--- a/custom_components/echonetlite/config_flow.py
+++ b/custom_components/echonetlite/config_flow.py
@@ -12,13 +12,13 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import selector
 from pychonet.lib.const import ENL_SETMAP, ENL_GETMAP, ENL_UID, ENL_MANUFACTURER
 #from aioudp import UDPServer
 from pychonet.lib.udpserver import UDPServer
 # from pychonet import Factory
 from pychonet import ECHONETAPIClient
-from .const import DOMAIN, USER_OPTIONS, TEMP_OPTIONS
-
+from .const import DOMAIN, USER_OPTIONS, TEMP_OPTIONS, ENL_HVAC_MODE, CONF_OTHER_MODE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -176,6 +176,22 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                                 default=default_temp
                             ): vol.All(vol.Coerce(int), vol.Range(min=TEMP_OPTIONS[option]['min'], max=TEMP_OPTIONS[option]['max']))
                     })
+
+                # Handle setting for the operation mode "Other"
+                option_default = 'as_off'
+                if self._config_entry.options.get(CONF_OTHER_MODE) is not None:
+                    option_default = self._config_entry.options.get(CONF_OTHER_MODE)
+                data_schema_structure.update({
+                    vol.Optional(
+                        USER_OPTIONS[ENL_HVAC_MODE]['option'],
+                        default=option_default
+                    ): selector({
+                        "select": {
+                            "options": USER_OPTIONS[ENL_HVAC_MODE]['option_list'],
+                            "mode": "dropdown"
+                        }
+                    })
+                })
 
             elif instance['eojgc'] == 0x01 and instance['eojcc'] == 0x35:  # AirCleaner
                 for option in list(USER_OPTIONS.keys()):

--- a/custom_components/echonetlite/const.py
+++ b/custom_components/echonetlite/const.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
 )
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
 from pychonet.HomeAirConditioner import (
+    ENL_HVAC_MODE,
     ENL_FANSPEED,
     ENL_AIR_VERT,
     ENL_AIR_HORZ,
@@ -35,6 +36,7 @@ from pychonet.EchonetInstance import (
 DOMAIN = "echonetlite"
 CONF_STATE_CLASS = ATTR_STATE_CLASS
 CONF_ENSURE_ON = "ensureon"
+CONF_OTHER_MODE = "other_mode"
 DATA_STATE_ON = "On"
 DATA_STATE_OFF = "Off"
 TYPE_SWITCH = "switch"
@@ -345,6 +347,7 @@ USER_OPTIONS = {
     ENL_AIR_VERT:   {'option': 'swing_vert', 'option_list': AIRFLOW_VERT_OPTIONS},
     ENL_AUTO_DIRECTION: {'option': 'auto_direction', 'option_list': AUTO_DIRECTION_OPTIONS},
     ENL_SWING_MODE:     {'option': 'swing_mode', 'option_list': SWING_MODE_OPTIONS},
+    ENL_HVAC_MODE:  {'option': CONF_OTHER_MODE, 'option_list': [{'value': 'as_off', 'label': 'As Off'}, {'value': 'as_idle', 'label': 'As Idle'}]},
 }
 
 TEMP_OPTIONS = {"min_temp_heat": {"min":10, "max":25},

--- a/custom_components/echonetlite/translations/en.json
+++ b/custom_components/echonetlite/translations/en.json
@@ -28,6 +28,7 @@
             "init": {
                 "title": "ECHONET Lite HVAC Options",
                 "data": {
+                   "other_mode": "Handling of operation mode \"Other\"",
                    "fan_settings": "Configure Fan settings",
                    "swing_horiz": "Configure Horizontal Swing Settings",
                    "swing_vert": "Configure Vertical Swing Settings",

--- a/custom_components/echonetlite/translations/ja.json
+++ b/custom_components/echonetlite/translations/ja.json
@@ -28,6 +28,7 @@
             "init": {
                 "title": "ECHONET Lite 空調機器オプション",
                 "data": {
+                   "other_mode": "運転モード「その他」の取り扱い",
                    "fan_settings": "風量設定の構成",
                    "swing_horiz": "風向左右設定の構成",
                    "swing_vert": "風向上下設定の構成",


### PR DESCRIPTION
Some air conditioner models have an operation mode "other" other than auto, cooling, heating, dehumidification, and ventilation. This includes the internal cleaning mode after the operation is stopped.
Home Assistant doesn't support this "Other" mode, so we need to return an alternative mode.
It is a suggestion to allow the user option to select either "stop" or "idle" as the alternative mode.