### PR TITLE
Confirmed working with Panasonic echonet lite model (CS-xxDJ series)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -58,6 +58,10 @@ ECHONETLite互換機器で使用するためのHomeAssistantカスタムコン�
      * 加湿空気清浄機
          * KI-HS70
 
+* パナソニック
+     *  エアコン
+         *　CS-221DJ
+
 * コイズミ照明
      * スマートブリッジ AE50264E (https://www.koizumi-lt.co.jp/product/jyutaku/tree/ )
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ compatible ECHONETLite Devices:
      * Air Purifier
          * KI-HS70
 
+* Panasonic
+     * Air Conditioners
+         * CS-221DJ
+
 * Koizumi
      * Lighting system AE50264E bridge (https://www.koizumi-lt.co.jp/product/jyutaku/tree/ )
 


### PR DESCRIPTION
I added it to the en and ja readme's. Tested in Home Assistant 2022.7 and version 3.5.3 of this integration (both current as of today)

Photo from my home assistant dashboard (automatically added info/ controls shown):
![image](https://user-images.githubusercontent.com/16775438/179136667-31c8fa61-6d84-41dc-ac25-5d8599463805.png)

Device info from Devices page:
![image](https://user-images.githubusercontent.com/16775438/179136826-119f534c-1b2b-4722-85d4-373a01c6e0b4.png)

