### PR TITLE
Fixed the possibility duplicate of uids of switch

### DIFF
--- a/custom_components/echonetlite/switch.py
+++ b/custom_components/echonetlite/switch.py
@@ -64,7 +64,7 @@ class EchonetSwitch(SwitchEntity):
         self._on_vals = [self._on_value, self._options[CONF_SERVICE_DATA][DATA_STATE_ON], hex(self._options[CONF_SERVICE_DATA][DATA_STATE_ON])[2:]]
         self._attr_name = f"{config.title} {EPC_CODE[self._connector._eojgc][self._connector._eojcc][self._code]}"
         self._attr_icon = options[CONF_ICON]
-        self._uid = f'{self._connector._uid}-{self._code}'
+        self._uid = f'{self._connector._uid}-{self._connector._eojgc}-{self._connector._eojcc}-{self._connector._eojci}-{self._code}'
         self._device_name = name
         self._should_poll = True
         self.update_option_listener()


### PR DESCRIPTION
It is the same modification as #100. According to the specification, the UID (0x83) of the node is the same as the UID (0x83) of each object in the node. From this, the node's UID + Code can have duplicate IDs.

However, this fix invalidates the entity already configured in HA and creates a new entity with that entity ID + "_2".
The user must remove the disabled entity and remove "_2" from the entity ID of the new entity.