### PR TITLE
Add 'Mono Functional Lighting' as a LightEntity

### DIFF
--- a/custom_components/echonetlite/light.py
+++ b/custom_components/echonetlite/light.py
@@ -28,9 +28,10 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up entry."""
     entities = []
     for entity in hass.data[DOMAIN][config_entry.entry_id]:
-        if (
-            entity["instance"]["eojgc"] == 0x02 and entity["instance"]["eojcc"] == 0x90
-        ):  # General Lighting
+        eojgc = entity["instance"]["eojgc"]
+        eojcc = entity["instance"]["eojcc"]
+        if eojgc == 0x01 and eojcc in (0x90, 0x91):
+            # General Lighting (0x90), Mono Functional Lighting (0x91)
             _LOGGER.debug("Configuring ECHONETlite Light entity")
             entities.append(EchonetLight(config_entry.title, entity["echonetlite"]))
     _LOGGER.debug(f"Number of light devices to be added: {len(entities)}")

--- a/custom_components/echonetlite/light.py
+++ b/custom_components/echonetlite/light.py
@@ -30,7 +30,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     for entity in hass.data[DOMAIN][config_entry.entry_id]:
         eojgc = entity["instance"]["eojgc"]
         eojcc = entity["instance"]["eojcc"]
-        if eojgc == 0x01 and eojcc in (0x90, 0x91):
+        if eojgc == 0x02 and eojcc in (0x90, 0x91):
             # General Lighting (0x90), Mono Functional Lighting (0x91)
             _LOGGER.debug("Configuring ECHONETlite Light entity")
             entities.append(EchonetLight(config_entry.title, entity["echonetlite"]))

--- a/custom_components/echonetlite/switch.py
+++ b/custom_components/echonetlite/switch.py
@@ -50,9 +50,9 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
                                 set_enl_status = True
         # Auto configure of the power switch
         if (eojgc == 0x01 and eojcc in (0x30, 0x35)) or (
-            eojgc == 0x02 and eojcc == 0x90
+            eojgc == 0x02 and eojcc in (0x90, 0x91)
         ):
-            # Home air conditioner, Air cleaner, General Lighting
+            # Home air conditioner, Air cleaner, General Lighting, Mono Functional Lighting
             continue
         if not set_enl_status and ENL_STATUS in entity["instance"]["setmap"]:
             entities.append(


### PR DESCRIPTION
This fixes the issue I raised in https://github.com/scottyphillips/echonetlite_homeassistant/issues/153

I cleaned this up using `in (0x90, 0x91)` compared to the exact fix I made locally that fixed this for me, but I can't see any functional difference? I'm not the strongest with Python so would appreciate a double check on that :) 

Thank you @scottyphillips for your work on this integration - it's crazy how well this worked out the box. Will hopefully be able to contribute a bit more over time