### PR TITLE
climate: Return None for current temperature if not returned by device

### DIFF
--- a/custom_components/echonetlite/climate.py
+++ b/custom_components/echonetlite/climate.py
@@ -180,7 +180,8 @@ class EchonetClimate(ClimateEntity):
     def _set_attrs(self):
         """current temperature."""
         _val = self._connector._update_data.get(ENL_HVAC_ROOM_TEMP)
-        if _val == 126:
+        # 0x7F: Overflow, 0x80: Underflow, 0x7E:Value cannot be returned
+        if _val in {0x7F, 0x80, 0x7E}:
             _val = None
         self._attr_current_temperature = _val
 

--- a/custom_components/echonetlite/climate.py
+++ b/custom_components/echonetlite/climate.py
@@ -180,10 +180,8 @@ class EchonetClimate(ClimateEntity):
     def _set_attrs(self):
         """current temperature."""
         _val = self._connector._update_data.get(ENL_HVAC_ROOM_TEMP)
-        if _val != None and _val != 126:
-            self._attr_current_temperature = _val
-        else:
-            _val = self._connector._update_data.get(ENL_HVAC_SET_TEMP)
+        if _val == 126:
+            _val = None
         self._attr_current_temperature = _val
 
         """temperature we try to reach."""


### PR DESCRIPTION
Current code will fall-back to raw value of the SET_TEMP property if the device does not return a valid, but that has two problems:
- the value can be also unavailable and end up displayed as -3,
- SET_TEMP is the currently set temperature, so displaying it as the current room temperature can be confusing to the user.

Fix this by simply returning None if the device does not return the current room temperature.