### PR TITLE
Electric blinds & covers

### DIFF
--- a/custom_components/echonetlite/__init__.py
+++ b/custom_components/echonetlite/__init__.py
@@ -68,6 +68,7 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.TIME,
     Platform.NUMBER,
+    Platform.COVER,
 ]
 PARALLEL_UPDATES = 0
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1)

--- a/custom_components/echonetlite/__init__.py
+++ b/custom_components/echonetlite/__init__.py
@@ -75,6 +75,14 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=1)
 MAX_UPDATE_BATCH_SIZE = 10
 MIN_UPDATE_BATCH_SIZE = 3
 
+def get_device_name(
+    connector, config
+) -> str:
+    if connector._name:
+        return connector._name
+    if connector._instance._eojci > 1:
+        return f"{config.title} {connector._instance._eojci}"
+    return config.title
 
 def get_name_by_epc_code(
     jgc: int, jcc: int, code: int, unknown: str | None = None

--- a/custom_components/echonetlite/climate.py
+++ b/custom_components/echonetlite/climate.py
@@ -35,6 +35,7 @@ from homeassistant.const import (
     PRECISION_WHOLE,
     UnitOfTemperature,
 )
+from . import get_device_name
 from .const import DATA_STATE_ON, DOMAIN, OPTION_HA_UI_SWING
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
         if (
             entity["instance"]["eojgc"] == 0x01 and entity["instance"]["eojcc"] == 0x30
         ):  # Home Air Conditioner
-            entities.append(EchonetClimate(config_entry.title, entity["echonetlite"]))
+            entities.append(EchonetClimate(entity["echonetlite"], config_entry))
     async_add_devices(entities, True)
 
     platform = entity_platform.async_get_current_platform()
@@ -87,8 +88,9 @@ class EchonetClimate(ClimateEntity):
 
     _attr_translation_key = DOMAIN
 
-    def __init__(self, name, connector):
+    def __init__(self, connector, config):
         """Initialize the climate device."""
+        name = get_device_name(connector, config)
         self._attr_name = name
         self._device_name = name
         self._connector = connector  # new line

--- a/custom_components/echonetlite/const.py
+++ b/custom_components/echonetlite/const.py
@@ -224,76 +224,6 @@ ENL_OP_CODES = {
         },
     },
     0x02: {  # Housing/Facilities-related Device
-        0x60: {  # Electrically operated blind/shade
-            0xE0: {
-                CONF_ICON: "mdi:roller-shade",
-                CONF_ICONS: {
-                    OPEN: "mdi:roller-shade",
-                    CLOSE: "mdi:roller-shade-closed",
-                    STOP: "mdi:roller-shade",
-                },
-            }
-        },
-        0x61: {  # Electrically operated shutter
-            0xE0: {
-                CONF_ICON: "mdi:window-shutter-open",
-                CONF_ICONS: {
-                    OPEN: "mdi:window-shutter-open",
-                    CLOSE: "mdi:window-shutter",
-                    STOP: "mdi:window-shutter-open",
-                },
-            }
-        },
-        0x62: {  # Electrically operated curtain
-            0xE0: {
-                CONF_ICON: "mdi:curtains",
-                CONF_ICONS: {
-                    OPEN: "mdi:curtains",
-                    CLOSE: "mdi:curtains-closed",
-                    STOP: "mdi:curtains",
-                },
-            }
-        },
-        0x63: {  # Electrically operated rain sliding door/shutter
-            0xE0: {
-                CONF_ICON: "mdi:door-sliding-open",
-                CONF_ICONS: {
-                    OPEN: "mdi:door-sliding-open",
-                    CLOSE: "mdi:door-sliding",
-                    STOP: "mdi:door-sliding-open",
-                },
-            }
-        },
-        0x64: {  # Electrically operated gate
-            0xE0: {
-                CONF_ICON: "mdi:boom-gate-up-outline",
-                CONF_ICONS: {
-                    OPEN: "mdi:boom-gate-up-outline",
-                    CLOSE: "mdi:boom-gate-outline",
-                    STOP: "mdi:boom-gate-up-outline",
-                },
-            }
-        },
-        0x65: {  # Electrically operated window
-            0xE0: {
-                CONF_ICON: "mdi:window-open-variant",
-                CONF_ICONS: {
-                    OPEN: "mdi:window-open-variant",
-                    CLOSE: "mdi:window-closed-variant",
-                    STOP: "mdi:window-open-variant",
-                },
-            }
-        },
-        0x66: {  # Automatically operated entrance door/sliding door
-            0xE0: {
-                CONF_ICON: "mdi:door-sliding-open",
-                CONF_ICONS: {
-                    OPEN: "mdi:door-sliding-open",
-                    CLOSE: "mdi:door-sliding",
-                    STOP: "mdi:door-sliding-open",
-                },
-            }
-        },
         0x6B: {  # Electric water heater
             # 0xB0: , # "Automatic water heating setting",
             # 0xB1: , # "Automatic water temperature control setting",
@@ -956,6 +886,13 @@ NON_SETUP_SINGLE_ENYITY = {
         0x30: {ENL_HVAC_MODE, ENL_HVAC_SET_TEMP, ENL_HVAC_SILENT_MODE},
     },
     0x02: {
+        0x60: {0xE0, 0xE1, 0xE2, 0xE9, 0xEA},
+        0x61: {0xE0, 0xE1, 0xE2, 0xE9, 0xEA},
+        0x62: {0xE0, 0xE1, 0xE2, 0xE9, 0xEA},
+        0x63: {0xE0, 0xE1, 0xE2, 0xE9, 0xEA},
+        0x64: {0xE0, 0xE1, 0xE2, 0xE9, 0xEA},
+        0x65: {0xE0, 0xE1, 0xE2, 0xE9, 0xEA},
+        0x66: {0xE0, 0xE1, 0xE2, 0xE9, 0xEA},
         # General Lighting
         0x90: {ENL_BRIGHTNESS, ENL_COLOR_TEMP},
         # Single Function Lighting

--- a/custom_components/echonetlite/cover.py
+++ b/custom_components/echonetlite/cover.py
@@ -1,0 +1,201 @@
+import logging
+import math
+import asyncio
+
+from typing import Any
+from .const import DOMAIN, CONF_FORCE_POLLING
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    CoverEntity,
+    CoverEntityFeature,
+)
+
+from pychonet.lib.eojx import EOJX_CLASS
+from pychonet.ElectricBlind import ENL_OPENSTATE
+
+from homeassistant.util.percentage import (
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
+)
+
+ENL_OPENCLOSE_STATUS = 0xEA
+ENL_OPENING_LEVEL = 0xE1
+ENL_BLIND_ANGLE = 0xE2
+TILT_RANGE = (1, 180)
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up entry."""
+    entities = []
+    for entity in hass.data[DOMAIN][config_entry.entry_id]:
+        if entity['instance']['eojgc'] == 0x02 and entity['instance']['eojcc'] in (0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66):
+            # 0x60: "Electrically operated blind/shade"
+            # 0x61: "Electrically operated shutter"
+            # 0x62: "Electrically operated curtain"
+            # 0x63: "Electrically operated rain sliding door/shutter"
+            # 0x64: "Electrically operated gate"
+            # 0x65: "Electrically operated window"
+            # 0x66: "Automatically operated entrance door/sliding door"
+            name = f"{config_entry.title} {entity['instance']['eojci']}"
+            entities.append(EchonetCover(name, entity['echonetlite']))
+    async_add_devices(entities, True)
+
+
+class EchonetCover(CoverEntity):
+    """Representation of an ECHONETLite climate device."""
+
+    def __init__(self, name, connector):
+        """Initialize the cover device."""
+        self._name = name
+        self._device_name = name
+        self._connector = connector  # new line
+        self._uid = self._connector._uidi if self._connector._uidi else self._connector._uid
+        self._attr_is_closed = False
+        self._server_state = self._connector._api._state[
+            self._connector._instance._host
+        ]
+        self._olddata = {}
+        self._should_poll = True
+        self._support_flags = (
+            CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.SET_POSITION
+            | CoverEntityFeature.STOP
+        )
+
+        if ENL_BLIND_ANGLE in self._connector._update_data:
+            self._support_flags |= (
+                CoverEntityFeature.OPEN_TILT
+                | CoverEntityFeature.CLOSE_TILT
+                # not supported individually (just global STOP)
+                #| CoverEntityFeature.STOP_TILT
+                | CoverEntityFeature.SET_TILT_POSITION
+            )
+
+        self.update_attr()
+        self.update_option_listener()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        await self._connector._instance.setMessage(ENL_OPENSTATE, 0x42)
+        self._connector._update_data[ENL_OPENSTATE] = "close"
+        self._attr_is_opening = False
+        self._attr_is_closing = True
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        await self._connector._instance.setMessage(ENL_OPENSTATE, 0x41)
+        self._connector._update_data[ENL_OPENSTATE] = "open"
+        self._attr_is_closing = False
+        self._attr_is_opening = True
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        await self._connector._instance.setMessage(ENL_OPENSTATE, 0x43)
+        self._connector._update_data[ENL_OPENSTATE] = "stop"
+        self._attr_is_opening = False
+        self._attr_is_closing = False
+        await self._connector.async_update()
+        self.update_attr()
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        desired_position = kwargs[ATTR_POSITION]
+        current_position = self._attr_current_cover_position
+        await self._connector._instance.setMessage(ENL_OPENING_LEVEL, desired_position)
+        self._connector._update_data[ENL_OPENING_LEVEL] = hex(desired_position)
+        self._attr_is_opening = desired_position > current_position
+        self._attr_is_closing = desired_position < current_position
+
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+        await self._connector._instance.setMessage(ENL_BLIND_ANGLE, 0)
+        self._connector._update_data[ENL_BLIND_ANGLE] = hex(0)
+
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+        await self._connector._instance.setMessage(ENL_BLIND_ANGLE, 180)
+        self._connector._update_data[ENL_BLIND_ANGLE] = hex(180)
+
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+        tilt = math.ceil(percentage_to_ranged_value(TILT_RANGE, kwargs[ATTR_TILT_POSITION]))
+        await self._connector._instance.setMessage(ENL_BLIND_ANGLE, tilt)
+        self._connector._update_data[ENL_BLIND_ANGLE] = hex(tilt)
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Return the current position of the roller blind.
+
+        None is unknown, 0 is closed, 100 is fully open.
+        """
+        return int(self._connector._update_data[ENL_OPENING_LEVEL], 16)
+
+    async def async_update(self):
+        await self._connector.async_update()
+
+    def update_attr(self):
+        self._attr_current_cover_position = int(self._connector._update_data[ENL_OPENING_LEVEL], 16)
+        self._attr_is_closed = self._attr_current_cover_position == 0
+        if ENL_OPENCLOSE_STATUS in self._connector._update_data:
+            self._attr_is_opening = int(self._connector._update_data[ENL_OPENCLOSE_STATUS], 16) == 0x43
+            self._attr_is_closing = int(self._connector._update_data[ENL_OPENCLOSE_STATUS], 16) == 0x44
+        else:
+            self._attr_is_opening = self._connector._update_data[ENL_OPENSTATE] == "open"
+            self._attr_is_closing = self._connector._update_data[ENL_OPENSTATE] == "close"
+        if ENL_BLIND_ANGLE in self._connector._update_data:
+            self._attr_current_cover_tilt_position = ranged_value_to_percentage(TILT_RANGE, int(self._connector._update_data[ENL_BLIND_ANGLE], 16))
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return self._support_flags
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._uid
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(
+                DOMAIN, self._connector._uid,
+                self._connector._instance._eojgc,
+                self._connector._instance._eojcc,
+                self._connector._instance._eojci
+            )},
+            "name": self._device_name,
+            "manufacturer": self._connector._manufacturer,
+            "model": EOJX_CLASS[self._connector._instance._eojgc][self._connector._instance._eojcc]
+            # "sw_version": "",
+        }
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return self._should_poll
+
+    @property
+    def name(self):
+        """Return the name of the climate device."""
+        return self._name
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        self._connector.add_update_option_listener(self.update_option_listener)
+        self._connector.register_async_update_callbacks(self.async_update_callback)
+
+    async def async_update_callback(self, isPush = False):
+        changed = (
+            self._olddata != self._connector._update_data
+        ) or self._attr_available != self._server_state["available"]
+        if changed:
+            self._olddata = self._connector._update_data.copy()
+            self.update_attr()
+            if self._attr_available != self._server_state["available"]:
+                if self._server_state["available"]:
+                    self.update_option_listener()
+                else:
+                    self._attr_should_poll = True
+            self._attr_available = self._server_state["available"]
+            self.async_schedule_update_ha_state()
+
+    def update_option_listener(self):
+        self._should_poll = True
+        _LOGGER.info(f"{self._device_name}: _should_poll is {self._should_poll}")

--- a/custom_components/echonetlite/fan.py
+++ b/custom_components/echonetlite/fan.py
@@ -7,6 +7,7 @@ from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.const import (
     PRECISION_WHOLE,
 )
+from . import get_device_name
 from .const import CONF_FORCE_POLLING, DATA_STATE_ON, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,15 +29,16 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
         if entity["instance"]["eojgc"] == 0x01 and (
             entity["instance"]["eojcc"] == 0x35 or entity["instance"]["eojcc"] == 0x3A
         ):  # Home Air Cleaner or Celing Fan
-            entities.append(EchonetFan(config_entry.title, entity["echonetlite"]))
+            entities.append(EchonetFan(entity["echonetlite"], config_entry))
     async_add_devices(entities, True)
 
 
 class EchonetFan(FanEntity):
     """Representation of an ECHONETLite Fan device (eg Air purifier)."""
 
-    def __init__(self, name, connector):
+    def __init__(self, connector, config):
         """Initialize the climate device."""
+        name = get_device_name(connector, config)
         self._attr_name = name
         self._device_name = name
         self._connector = connector  # new line

--- a/custom_components/echonetlite/light.py
+++ b/custom_components/echonetlite/light.py
@@ -12,6 +12,7 @@ from homeassistant.components.light import (
     COLOR_MODE_COLOR_TEMP,
 )
 
+from . import get_device_name
 from .const import DATA_STATE_ON, DOMAIN, CONF_FORCE_POLLING
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,8 +34,8 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
             _LOGGER.debug("Configuring ECHONETlite Light entity")
             entities.append(
                 EchonetLight(
-                    entity["echonetlite"]._name or config_entry.title,
                     entity["echonetlite"],
+                    config_entry,
                 )
             )
     _LOGGER.debug(f"Number of light devices to be added: {len(entities)}")
@@ -44,8 +45,9 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 class EchonetLight(LightEntity):
     """Representation of a ECHONET light device."""
 
-    def __init__(self, name, connector):
+    def __init__(self, connector, config):
         """Initialize the climate device."""
+        name = get_device_name(connector, config)
         self._attr_name = name
         self._connector = connector  # new line
         self._attr_unique_id = (

--- a/custom_components/echonetlite/number.py
+++ b/custom_components/echonetlite/number.py
@@ -9,7 +9,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import InvalidStateError
 from homeassistant.components.number import NumberEntity
 from pychonet.lib.eojx import EOJX_CLASS
-from . import get_name_by_epc_code, get_unit_by_devise_class
+from . import get_name_by_epc_code, get_unit_by_devise_class, get_device_name
 from .const import (
     DOMAIN,
     CONF_FORCE_POLLING,
@@ -38,8 +38,7 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
                         entity["echonetlite"],
                         config,
                         op_code,
-                        _enl_op_codes[op_code],
-                        entity["echonetlite"]._name or config.title,
+                        _enl_op_codes[op_code]
                     )
                 )
 
@@ -49,7 +48,7 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
 class EchonetNumber(NumberEntity):
     _attr_translation_key = DOMAIN
 
-    def __init__(self, hass, connector, config, code, options, name=None):
+    def __init__(self, hass, connector, config, code, options):
         """Initialize the number."""
         self._connector = connector
         self._config = config
@@ -70,7 +69,7 @@ class EchonetNumber(NumberEntity):
         self._conf_max = int(options[TYPE_NUMBER][CONF_MAXIMUM])
         self._byte_length = int(options[TYPE_NUMBER].get(CONF_BYTE_LENGTH, 1))
 
-        self._device_name = name
+        self._device_name = get_device_name(connector, config)
         self._attr_device_class = self._options.get(
             CONF_TYPE, options.get(CONF_TYPE, None)
         )

--- a/custom_components/echonetlite/select.py
+++ b/custom_components/echonetlite/select.py
@@ -8,6 +8,7 @@ from .const import (
     ENL_OP_CODES,
     CONF_ICONS,
     TYPE_SELECT,
+    NON_SETUP_SINGLE_ENYITY,
 )
 from pychonet.lib.eojx import EOJX_CLASS
 from pychonet.lib.epc_functions import _swap_dict
@@ -21,11 +22,16 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
         eojgc = entity["instance"]["eojgc"]
         eojcc = entity["instance"]["eojcc"]
         _enl_op_codes = ENL_OP_CODES.get(eojgc, {}).get(eojcc, {})
+        _non_setup_single_entity = NON_SETUP_SINGLE_ENYITY.get(eojgc, {}).get(
+            eojcc, set()
+        )
         # configure select entities by looking up full ENL_OP_CODE dict
         for op_code in entity["instance"]["setmap"]:
             epc_function_data = entity["echonetlite"]._instance.EPC_FUNCTIONS.get(
                 op_code, None
             )
+            if op_code in _non_setup_single_entity:
+                continue
             _by_epc_func = (
                 type(epc_function_data) == list
                 and type(epc_function_data[1]) == dict

--- a/custom_components/echonetlite/select.py
+++ b/custom_components/echonetlite/select.py
@@ -1,7 +1,7 @@
 import logging
 from homeassistant.const import CONF_ICON
 from homeassistant.components.select import SelectEntity
-from . import get_name_by_epc_code
+from . import get_name_by_epc_code, get_device_name
 from .const import (
     DOMAIN,
     CONF_FORCE_POLLING,
@@ -46,7 +46,6 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
                         config,
                         op_code,
                         _enl_op_code_dict,
-                        entity["echonetlite"]._name or config.title,
                     )
                 )
 
@@ -56,8 +55,9 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
 class EchonetSelect(SelectEntity):
     _attr_translation_key = DOMAIN
 
-    def __init__(self, hass, connector, config, code, options, name=None):
+    def __init__(self, hass, connector, config, code, options):
         """Initialize the select."""
+        name = get_device_name(connector, config)
         self._connector = connector
         self._config = config
         self._code = code

--- a/custom_components/echonetlite/sensor.py
+++ b/custom_components/echonetlite/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.exceptions import InvalidStateError, NoEntitySpecifiedError
 from pychonet.lib.eojx import EOJX_CLASS
 from pychonet.lib.epc_functions import EPC_SUPER_FUNCTIONS, _hh_mm
 
-from . import get_name_by_epc_code, get_unit_by_devise_class
+from . import get_name_by_epc_code, get_unit_by_devise_class, get_device_name
 from .const import (
     DOMAIN,
     ENABLE_SUPER_ENERGY_DEFAULT,
@@ -150,9 +150,9 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
                             entities.append(
                                 EchonetSensor(
                                     entity["echonetlite"],
+                                    config,
                                     op_code,
                                     _enl_op_codes.get(op_code) | {"dict_key": attr_key},
-                                    entity["echonetlite"]._name or config.title,
                                     hass,
                                 )
                             )
@@ -175,9 +175,9 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
                         entities.append(
                             EchonetSensor(
                                 entity["echonetlite"],
+                                config,
                                 op_code,
                                 attr,
-                                config.title,
                             )
                         )
                     continue
@@ -185,9 +185,9 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
                     entities.append(
                         EchonetSensor(
                             entity["echonetlite"],
+                            config,
                             op_code,
                             _enl_op_codes[op_code],
-                            entity["echonetlite"]._name or config.title,
                             hass,
                         )
                     )
@@ -195,9 +195,9 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
             entities.append(
                 EchonetSensor(
                     entity["echonetlite"],
+                    config,
                     op_code,
                     ENL_OP_CODES["default"],
-                    entity["echonetlite"]._name or config.title,
                 )
             )
     async_add_entities(entities, True)
@@ -208,8 +208,9 @@ class EchonetSensor(SensorEntity):
 
     _attr_translation_key = DOMAIN
 
-    def __init__(self, connector, op_code, attributes, name=None, hass=None) -> None:
+    def __init__(self, connector, config, op_code, attributes, hass=None) -> None:
         """Initialize the sensor."""
+        name = get_device_name(connector, config)
         self._connector = connector
         self._op_code = op_code
         self._sensor_attributes = attributes

--- a/custom_components/echonetlite/switch.py
+++ b/custom_components/echonetlite/switch.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from homeassistant.const import CONF_ICON, CONF_SERVICE_DATA, CONF_NAME
 from homeassistant.components.switch import SwitchEntity
-from . import get_name_by_epc_code
+from . import get_name_by_epc_code, get_device_name
 from .const import (
     DOMAIN,
     ENL_OP_CODES,
@@ -48,7 +48,6 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
                         config,
                         op_code,
                         _enl_op_code_dict,
-                        entity["echonetlite"]._name or config.title,
                     )
                 )
                 if op_code == ENL_STATUS:
@@ -66,7 +65,6 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
                         config,
                         op_code,
                         switch_conf,
-                        entity["echonetlite"]._name or config.title,
                     )
                 )
         # Auto configure of the power switch
@@ -86,15 +84,15 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
                         CONF_ICON: "mdi:power-settings",
                         CONF_SERVICE_DATA: SWITCH_POWER,
                     },
-                    entity["echonetlite"]._name or config.title,
                 )
             )
     async_add_entities(entities, True)
 
 
 class EchonetSwitch(SwitchEntity):
-    def __init__(self, hass, connector, config, code, options, name=None):
+    def __init__(self, hass, connector, config, code, options):
         """Initialize the switch."""
+        name = get_device_name(connector, config)
         self._connector = connector
         self._config = config
         self._code = code

--- a/custom_components/echonetlite/time.py
+++ b/custom_components/echonetlite/time.py
@@ -4,7 +4,7 @@ from datetime import time
 from homeassistant.const import CONF_ICON
 from homeassistant.components.time import TimeEntity
 from homeassistant.exceptions import InvalidStateError
-from . import get_name_by_epc_code
+from . import get_name_by_epc_code, get_device_name
 from .const import (
     DOMAIN,
     CONF_FORCE_POLLING,
@@ -40,7 +40,6 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
                         config,
                         op_code,
                         _enl_op_codes.get(op_code, {}),
-                        entity["echonetlite"]._name or config.title,
                     )
                 )
 
@@ -66,7 +65,7 @@ class EchonetTime(TimeEntity):
             else f"{self._connector._uid}-{self._code}"
         )
 
-        self._device_name = device_name
+        self._device_name = get_device_name(connector, config)
         self._attr_native_value = self.get_time()
         self._attr_should_poll = True
         self._attr_available = True


### PR DESCRIPTION
Add support for blind and covers.
I will test it over next few days to make sure it doesn't degrade over time.

One issue I noticed is, if I issue a tilt command while blind is moving up/down, it will go back all the way up.
I assume this is probably a problem only with my specific blind system, so I was hesitating to make a workaround (i.e. wait until blind not moving before issuing tilt command).

Note: I had to filter `select` with `NON_SETUP_SINGLE_ENYITY` so that it doesn't appear anymore in the list (so far, only `sensor` were filtered). Maybe we want to generalize `NON_SETUP_SINGLE_ENYITY` to any other entity types as well?