### PR TITLE
Fix #179 Energy-related sensors are not enabled by default

### DIFF
--- a/custom_components/echonetlite/__init__.py
+++ b/custom_components/echonetlite/__init__.py
@@ -555,7 +555,7 @@ class ECHONETConnector:
         # Is enabled CONF_ENABLE_SUPER_ENERGY
         _enabled_super_energy = self._user_options.get(
             CONF_ENABLE_SUPER_ENERGY,
-            ENABLE_SUPER_ENERGY_DEFAULT.get(self._eojgc, {}).get(self._eojcc, False),
+            ENABLE_SUPER_ENERGY_DEFAULT.get(self._eojgc, {}).get(self._eojcc, True),
         )
         # Some classes use predefined data (Narrowed down items)
         flags = EPC_CODES_FOR_UPDATE.get(self._eojgc, {}).get(self._eojcc, None)

--- a/custom_components/echonetlite/const.py
+++ b/custom_components/echonetlite/const.py
@@ -1048,8 +1048,6 @@ EPC_CODES_FOR_UPDATE = {
             ENL_HVAC_ROOM_TEMP,
             ENL_HVAC_OUT_TEMP,
             ENL_HVAC_SILENT_MODE,
-            ENL_INSTANTANEOUS_POWER,
-            ENL_CUMULATIVE_POWER,
         ],
     },
     0x02: {

--- a/custom_components/echonetlite/sensor.py
+++ b/custom_components/echonetlite/sensor.py
@@ -74,7 +74,7 @@ async def async_setup_entry(hass, config, async_add_entities, discovery_info=Non
 
         if entity["echonetlite"]._user_options.get(
             CONF_ENABLE_SUPER_ENERGY,
-            ENABLE_SUPER_ENERGY_DEFAULT.get(eojgc, {}).get(eojcc, False),
+            ENABLE_SUPER_ENERGY_DEFAULT.get(eojgc, {}).get(eojcc, True),
         ):
             _enl_super_codes = ENL_SUPER_CODES
         else:


### PR DESCRIPTION
Resolves an issue where the device option "Enable energy-related sensors (if available)" should be enabled by default, but would not take effect unless the option was disabled and then enabled.