### PR TITLE
a typo?

### DIFF
--- a/custom_components/echonetlite/const.py
+++ b/custom_components/echonetlite/const.py
@@ -999,7 +999,7 @@ ENL_OP_CODES = {
         },
     },
     0x03: {  # Cooking/housework-related device class group
-        0x7B: {  # Refrigerator
+        0xB7: {  # Refrigerator
             0xB0: {
                 CONF_ICON: "mdi:door",
                 CONF_ICONS: {


### PR DESCRIPTION
I am a novice user of home assistant and I have almost no knowledge how it works, but I hope this would be a fix of the fridge implementation of echonetlite.

![image](https://github.com/scottyphillips/echonetlite_homeassistant/assets/16380686/6a1fc364-bcde-455f-adf1-ea8a10a12aac)

This is a snapshot of my fridge sensor status. I applied my fix a few minute ago, and the status looks good.