### PR TITLE
HA 2025.8.0b0 fix Update __init__.py

### DIFF
--- a/custom_components/echonetlite/__init__.py
+++ b/custom_components/echonetlite/__init__.py
@@ -200,7 +200,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if DOMAIN in hass.data:  # maybe set up by config entry?
         _LOGGER.debug(f"ECHONETlite platform is already started.")
-        server = hass.data[DOMAIN]["api"]
+        server = hass.data.get(DOMAIN, {}).get("api")
         hass.data[DOMAIN].update({entry.entry_id: []})
     else:  # setup API
         _LOGGER.debug(f"Starting up ECHONETlite platform..")


### PR DESCRIPTION
No longer working with HA 2025.8.0b0.

Changed 
server = hass.data[DOMAIN]["api"]

to

server = hass.data.get(DOMAIN, {}).get("api")