### PR TITLE
feat(climate): normalize target temperature to 1°C resolution

### DIFF
--- a/custom_components/echonetlite/__init__.py
+++ b/custom_components/echonetlite/__init__.py
@@ -1,50 +1,53 @@
 """The echonetlite integration."""
 
 from __future__ import annotations
-import os
-from importlib import import_module
-import logging
+
 import asyncio
-from functools import partial
-from typing import Any
-import pychonet as echonet
-from pychonet.echonetapiclient import EchonetMaxOpcError
-from pychonet.lib.epc import EPC_SUPER, EPC_CODE
-from pychonet.lib.const import VERSION, ENL_STATMAP
+import logging
+import os
 from datetime import timedelta
+from functools import partial
+from importlib import import_module
+from typing import Any
+
+import pychonet as echonet
 from homeassistant import config_entries
+from homeassistant.components.number.const import NumberDeviceClass
+from homeassistant.components.sensor.const import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.util import Throttle
 from homeassistant.const import (
     CONF_NAME,
-    Platform,
     PERCENTAGE,
-    UnitOfPower,
-    UnitOfTemperature,
-    UnitOfEnergy,
-    UnitOfVolume,
+    Platform,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfVolume,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.components.sensor.const import SensorDeviceClass
-from homeassistant.components.number.const import NumberDeviceClass
-from .const import (
-    CONF_ENABLE_SUPER_ENERGY,
-    DOMAIN,
-    ENABLE_SUPER_ENERGY_DEFAULT,
-    ENL_OP_CODES,
-    ENL_SUPER_CODES,
-    ENL_SUPER_ENERGES,
-    ENL_TIMER_SETTING,
-    USER_OPTIONS,
-    TEMP_OPTIONS,
-    CONF_BATCH_SIZE_MAX,
-    MISC_OPTIONS,
+from homeassistant.util import Throttle
+from pychonet import ECHONETAPIClient
+from pychonet.echonetapiclient import EchonetMaxOpcError
+from pychonet.EchonetInstance import (
+    ENL_CUMULATIVE_POWER,
+    ENL_GETMAP,
+    ENL_INSTANTANEOUS_POWER,
+    ENL_SETMAP,
+    ENL_STATUS,
+    ENL_UID,
 )
-from .config_flow import enumerate_instances, async_discover_newhost, ErrorConnect
-from pychonet.lib.udpserver import UDPServer
+from pychonet.HomeAirConditioner import (
+    ENL_AIR_HORZ,
+    ENL_AIR_VERT,
+    ENL_AUTO_DIRECTION,
+    ENL_FANSPEED,
+    ENL_SWING_MODE,
+)
+from pychonet.lib.const import ENL_STATMAP, VERSION
+from pychonet.lib.epc import EPC_CODE, EPC_SUPER
 from pychonet.lib.epc_functions import (
     DICT_30_ON_OFF,
     DICT_30_OPEN_CLOSED,
@@ -52,24 +55,22 @@ from pychonet.lib.epc_functions import (
     DICT_41_ON_OFF,
     _hh_mm,
 )
+from pychonet.lib.udpserver import UDPServer
 
-from pychonet import ECHONETAPIClient
-from pychonet.EchonetInstance import (
-    ENL_GETMAP,
-    ENL_SETMAP,
-    ENL_UID,
-    ENL_STATUS,
-    ENL_INSTANTANEOUS_POWER,
-    ENL_CUMULATIVE_POWER,
+from .config_flow import ErrorConnect, async_discover_newhost, enumerate_instances
+from .const import (
+    CONF_BATCH_SIZE_MAX,
+    CONF_ENABLE_SUPER_ENERGY,
+    DOMAIN,
+    ENABLE_SUPER_ENERGY_DEFAULT,
+    ENL_OP_CODES,
+    ENL_SUPER_CODES,
+    ENL_SUPER_ENERGES,
+    ENL_TIMER_SETTING,
+    MISC_OPTIONS,
+    TEMP_OPTIONS,
+    USER_OPTIONS,
 )
-from pychonet.HomeAirConditioner import (
-    ENL_FANSPEED,
-    ENL_AUTO_DIRECTION,
-    ENL_SWING_MODE,
-    ENL_AIR_VERT,
-    ENL_AIR_HORZ,
-)
-
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [
@@ -129,7 +130,7 @@ def get_name_by_epc_code(
 def polling_update_debug_log(values: dict[int, Any], conn_instance: ECHONETConnector):
     eojgc = conn_instance._eojgc
     eojcc = conn_instance._eojcc
-    debug_log = f"\nECHONETlite polling update data:\n"
+    debug_log = "\nECHONETlite polling update data:\n"
     for value in list(values.keys()):
         name = conn_instance._enl_op_codes.get(value, {}).get(CONF_NAME)
         debug_log = (
@@ -234,11 +235,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(unload_config_entry)
 
     if DOMAIN in hass.data:  # maybe set up by config entry?
-        _LOGGER.debug(f"ECHONETlite platform is already started.")
+        _LOGGER.debug("ECHONETlite platform is already started.")
         server = hass.data[DOMAIN]["api"]
         hass.data[DOMAIN].update({entry.entry_id: []})
     else:  # setup API
-        _LOGGER.debug(f"Starting up ECHONETlite platform..")
+        _LOGGER.debug("Starting up ECHONETlite platform..")
         _LOGGER.debug(f"pychonet version is {VERSION}")
         hass.data.setdefault(DOMAIN, {})
         hass.data[DOMAIN].update({entry.entry_id: []})
@@ -367,7 +368,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         {"instance": instance, "echonetlite": echonetlite}
                     )
                     break
-                except TimeoutError as ex:
+                except TimeoutError:
                     _LOGGER.debug(
                         f"Setting up ECHONET Instance host {host} timed out. Retry {retry} of 3"
                     )
@@ -620,7 +621,7 @@ class ECHONETConnector:
             _enl_super_codes = ENL_SUPER_CODES
         else:
             _enl_super_codes = {
-                k: v for k, v in ENL_SUPER_CODES.items() if not k in ENL_SUPER_ENERGES
+                k: v for k, v in ENL_SUPER_CODES.items() if k not in ENL_SUPER_ENERGES
             }
         flags += list(_enl_super_codes)
 

--- a/custom_components/echonetlite/climate.py
+++ b/custom_components/echonetlite/climate.py
@@ -397,6 +397,18 @@ class EchonetClimate(ClimateEntity):
             self.async_schedule_update_ha_state()
 
     def _normalize_settemp(self, req: float | int | None) -> int | None:
+        """
+        Normalize a requested temperature to the 1°C resolution supported by
+        ECHONET Lite HVAC devices.
+
+        Matter controllers may send fractional values (e.g., 22.5°C). Since most
+        ECHONET air conditioners accept only integer setpoints, this function
+        converts the request to a valid value while preserving user intent:
+        - Integer values are used as-is.
+        - `.5` values are rounded directionally based on the previous target
+          temperature (up when increasing, down when decreasing).
+        - Other fractions are rounded to the nearest integer.
+        """
         if req is None:
             return None
 

--- a/custom_components/echonetlite/climate.py
+++ b/custom_components/echonetlite/climate.py
@@ -1,40 +1,40 @@
 import logging
-
-from pychonet.HomeAirConditioner import (
-    AIRFLOW_VERT,
-    ENL_STATUS,
-    ENL_FANSPEED,
-    ENL_AIR_VERT,
-    ENL_AUTO_DIRECTION,
-    ENL_SWING_MODE,
-    ENL_HVAC_MODE,
-    ENL_HVAC_SET_TEMP,
-    ENL_HVAC_SET_HUMIDITY,
-    ENL_HVAC_ROOM_TEMP,
-    ENL_HVAC_SILENT_MODE,
-    FAN_SPEED,
-    SILENT_MODE,
-)
-
-from pychonet.lib.eojx import EOJX_CLASS
+import math
 
 import voluptuous as vol
-
 from homeassistant.components.climate import (
     ClimateEntity,
 )
-from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.components.climate.const import (
+    ATTR_HVAC_MODE,
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
-    ATTR_HVAC_MODE,
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     PRECISION_WHOLE,
     UnitOfTemperature,
 )
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_platform
+from pychonet.HomeAirConditioner import (
+    AIRFLOW_VERT,
+    ENL_AIR_VERT,
+    ENL_AUTO_DIRECTION,
+    ENL_FANSPEED,
+    ENL_HVAC_MODE,
+    ENL_HVAC_ROOM_TEMP,
+    ENL_HVAC_SET_HUMIDITY,
+    ENL_HVAC_SET_TEMP,
+    ENL_HVAC_SILENT_MODE,
+    ENL_STATUS,
+    ENL_SWING_MODE,
+    FAN_SPEED,
+    SILENT_MODE,
+)
+from pychonet.lib.eojx import EOJX_CLASS
+
 from . import get_device_name
 from .const import DATA_STATE_ON, DOMAIN, OPTION_HA_UI_SWING
 
@@ -328,10 +328,9 @@ class EchonetClimate(ClimateEntity):
         if hvac_mode is not None:
             await self.async_set_hvac_mode(hvac_mode)
 
+        settemp = self._normalize_settemp(kwargs.get(ATTR_TEMPERATURE))
         if kwargs.get(ATTR_TEMPERATURE) is not None:
-            await self._connector._instance.setOperationalTemperature(
-                kwargs.get(ATTR_TEMPERATURE)
-            )
+            await self._connector._instance.setOperationalTemperature(settemp)
 
     async def async_set_humidity(self, humidity: int) -> None:
         await self._connector._instance.setOperationalTemperature(humidity)
@@ -396,3 +395,24 @@ class EchonetClimate(ClimateEntity):
         self._set_min_max_temp()
         if self.hass:
             self.async_schedule_update_ha_state()
+
+    def _normalize_settemp(self, req: float | int | None) -> int | None:
+        if req is None:
+            return None
+
+        res = None
+        if abs(req - round(req)) < 1e-9:
+            res = int(round(req))
+        else:
+            prev = self._attr_target_temperature
+            frac = req - math.floor(req)
+
+            if abs(frac - 0.5) < 1e-9 and prev is not None:
+                if req >= prev:
+                    res = math.ceil(req)
+                if req < prev:
+                    res = math.floor(req)
+            else:
+                res = int(math.floor(req + 0.5))
+
+        return res


### PR DESCRIPTION
### Summary
This change normalizes requested target temperatures to match the 1°C resolution
used by most ECHONET Lite air conditioners when receiving values from Matter
controllers (e.g., Google Home).

Matter Thermostat clusters allow high-resolution setpoints (e.g., 0.5°C), while
many Japanese HVAC devices only support integer temperature settings. This mismatch
can lead to confusing UX where controllers accept fractional values but the device
must coerce them to discrete steps.

### What this PR does
- Introduces `_normalize_settemp()` to convert requested temperatures into valid integer setpoints before sending them to the device.
- Applies direction-aware rounding for `.5°C` inputs:
  - If the requested value increases relative to the previous setpoint, it rounds up.
  - If it decreases, it rounds down.
- Uses nearest-integer rounding for other fractional values.
- Ensures device behavior aligns with user intent when operating via Matter bridges or external controllers.

### Why this is needed
Some Matter controllers expose 0.5°C adjustment even when the underlying HVAC only
supports 1°C steps. Without normalization:
- The device silently coerces values, appearing unresponsive.
- UI and actual device state can appear inconsistent.
- Users may perceive this as a synchronization bug.

By normalizing inside the integration, we provide deterministic behavior and better
cross-platform interoperability.

### Scope
- No change for integrations already sending integer values.
- Only affects temperature writes (`async_set_temperature`).
- Does not modify device read/state logic.

### Notes
This is particularly relevant for multi-controller Matter environments where
resolution differences between the abstract data model and physical HVAC devices
become visible.