### PR TITLE
Update Japanese translations for echonetlite states

### DIFF
--- a/custom_components/echonetlite/translations/ja.json
+++ b/custom_components/echonetlite/translations/ja.json
@@ -66,9 +66,9 @@
         "sensor": {
             "echonetlite": {
                 "state": {
-                    "Stopped": "停止",
-                    "Supplying Hot Water": "湯はり中",
-                    "Keeping Bath Temperature": "保温中",
+                    "stopped": "停止",
+                    "supplying hot water": "湯はり中",
+                    "keeping bath temperature": "保温中",
                     "heating": "加温中",
                     "not heating": "停止"
                 }


### PR DESCRIPTION
Fix Japanese translation keys capitalization in sensor states

The sensor state translation keys in ja.json were using incorrect capitalization (e.g., "Stopped", "Supplying Hot Water", "Keeping Bath Temperature"), which prevented translations from being applied in Home Assistant.

Changed the following keys to lowercase to match en.json:
- "Stopped" → "stopped"
- "Supplying Hot Water" → "supplying hot water"
- "Keeping Bath Temperature" → "keeping bath temperature"

This fix ensures Japanese translations are correctly displayed for sensor states in Home Assistant's UI.

Fixes: Translation keys not matching between ja.json and en.json