### PR TITLE
Restore horizontal swing mode to climate entity

### DIFF
--- a/custom_components/echonetlite/climate.py
+++ b/custom_components/echonetlite/climate.py
@@ -19,7 +19,9 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform
 from pychonet.HomeAirConditioner import (
+    AIRFLOW_HORIZ,
     AIRFLOW_VERT,
+    ENL_AIR_HORZ,
     ENL_AIR_VERT,
     ENL_AUTO_DIRECTION,
     ENL_FANSPEED,
@@ -54,6 +56,7 @@ DEFAULT_HVAC_MODES = [
 DEFAULT_SWING_MODES = ["auto-vert"] + list(
     AIRFLOW_VERT.keys()
 )  # ["auto-vert","upper","upper-central","central","lower-central","lower"]
+DEFAULT_SWING_HORIZ_MODES = list(AIRFLOW_HORIZ.keys())
 DEFAULT_PRESET_MODES = list(SILENT_MODE.keys())  # ["normal", "high-speed", "silent"]
 
 SERVICE_SET_HUMIDIFER_DURING_HEATER = "set_humidifier_during_heater"
@@ -133,6 +136,12 @@ class EchonetClimate(ClimateEntity):
             self._attr_supported_features = (
                 self._attr_supported_features | ClimateEntityFeature.SWING_MODE
             )
+        if ENL_AIR_HORZ in list(self._connector._setPropertyMap):
+            if hasattr(ClimateEntityFeature, "SWING_HORIZONTAL_MODE"):
+                self._attr_supported_features = (
+                    self._attr_supported_features
+                    | ClimateEntityFeature.SWING_HORIZONTAL_MODE
+                )
         if ENL_HVAC_SILENT_MODE in list(self._connector._setPropertyMap):
             self._attr_supported_features = (
                 self._attr_supported_features | ClimateEntityFeature.PRESET_MODE
@@ -301,6 +310,12 @@ class EchonetClimate(ClimateEntity):
                 else None
             )
 
+        """horizontal swing mode setting."""
+        if ENL_AIR_HORZ in self._connector._setPropertyMap:
+            self._attr_swing_horizontal_mode = (
+                self._connector._update_data.get(ENL_AIR_HORZ)
+            )
+
         self._set_min_max_temp()
 
     async def async_set_fan_mode(self, fan_mode):
@@ -320,6 +335,10 @@ class EchonetClimate(ClimateEntity):
             await self._connector._instance.setSwingMode(swing_mode)
         else:
             await self._connector._instance.setAirflowVert(swing_mode)
+
+    async def async_set_swing_horizontal_mode(self, swing_horizontal_mode):
+        """Set new horizontal swing mode."""
+        await self._connector._instance.setAirflowHoriz(swing_horizontal_mode)
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperatures."""
@@ -391,6 +410,14 @@ class EchonetClimate(ClimateEntity):
             self._attr_swing_modes = _modes
         else:
             self._attr_swing_modes = DEFAULT_SWING_MODES
+
+        """list of available horizontal swing modes."""
+        if ENL_AIR_HORZ in self._connector._setPropertyMap:
+            _modes = self._connector._user_options.get(ENL_AIR_HORZ)
+            if _modes:
+                self._attr_swing_horizontal_modes = _modes
+            else:
+                self._attr_swing_horizontal_modes = DEFAULT_SWING_HORIZ_MODES
 
         self._set_min_max_temp()
         if self.hass:

--- a/custom_components/echonetlite/climate.py
+++ b/custom_components/echonetlite/climate.py
@@ -311,10 +311,26 @@ class EchonetClimate(ClimateEntity):
             )
 
         """horizontal swing mode setting."""
-        if ENL_AIR_HORZ in self._connector._setPropertyMap:
-            self._attr_swing_horizontal_mode = (
-                self._connector._update_data.get(ENL_AIR_HORZ)
-            )
+        if hasattr(self, "_attr_swing_horizontal_modes"):
+            _horiz_modes = self._attr_swing_horizontal_modes or []
+            if (
+                self._connector._update_data.get(ENL_AUTO_DIRECTION)
+                in _horiz_modes
+            ):
+                self._attr_swing_horizontal_mode = self._connector._update_data.get(
+                    ENL_AUTO_DIRECTION
+                )
+            elif (
+                self._connector._update_data.get(ENL_SWING_MODE)
+                in _horiz_modes
+            ):
+                self._attr_swing_horizontal_mode = self._connector._update_data.get(
+                    ENL_SWING_MODE
+                )
+            else:
+                self._attr_swing_horizontal_mode = (
+                    self._connector._update_data.get(ENL_AIR_HORZ)
+                )
 
         self._set_min_max_temp()
 
@@ -338,7 +354,12 @@ class EchonetClimate(ClimateEntity):
 
     async def async_set_swing_horizontal_mode(self, swing_horizontal_mode):
         """Set new horizontal swing mode."""
-        await self._connector._instance.setAirflowHoriz(swing_horizontal_mode)
+        if swing_horizontal_mode in self._opc_data[ENL_AUTO_DIRECTION]:
+            await self._connector._instance.setAutoDirection(swing_horizontal_mode)
+        elif swing_horizontal_mode in self._opc_data[ENL_SWING_MODE]:
+            await self._connector._instance.setSwingMode(swing_horizontal_mode)
+        else:
+            await self._connector._instance.setAirflowHoriz(swing_horizontal_mode)
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperatures."""
@@ -413,11 +434,21 @@ class EchonetClimate(ClimateEntity):
 
         """list of available horizontal swing modes."""
         if ENL_AIR_HORZ in self._connector._setPropertyMap:
+            horiz_modes = []
+            # Add horizontal oscillation modes from auto direction and swing mode
+            for mode in self._opc_data[ENL_AUTO_DIRECTION]:
+                if mode in ("auto-horiz",):
+                    horiz_modes.append(mode)
+            for mode in self._opc_data[ENL_SWING_MODE]:
+                if mode in ("horiz", "vert-horiz"):
+                    horiz_modes.append(mode)
+            # Add horizontal position modes
             _modes = self._connector._user_options.get(ENL_AIR_HORZ)
             if _modes:
-                self._attr_swing_horizontal_modes = _modes
+                horiz_modes.extend(_modes)
             else:
-                self._attr_swing_horizontal_modes = DEFAULT_SWING_HORIZ_MODES
+                horiz_modes.extend(DEFAULT_SWING_HORIZ_MODES)
+            self._attr_swing_horizontal_modes = horiz_modes
 
         self._set_min_max_temp()
         if self.hass:

--- a/custom_components/echonetlite/config_flow.py
+++ b/custom_components/echonetlite/config_flow.py
@@ -426,10 +426,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         for del_key in [
                             "auto",
                             "non-auto",
-                            "auto-horiz",
                             "not-used",
-                            "horiz",
-                            "vert-horiz",
                         ]:
                             option_list.pop(del_key, None)
                     if self._config_entry.options.get(OPTION_HA_UI_SWING) is not None:

--- a/custom_components/echonetlite/config_flow.py
+++ b/custom_components/echonetlite/config_flow.py
@@ -426,7 +426,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         for del_key in [
                             "auto",
                             "non-auto",
+                            "auto-horiz",
                             "not-used",
+                            "horiz",
+                            "vert-horiz",
                         ]:
                             option_list.pop(del_key, None)
                     if self._config_entry.options.get(OPTION_HA_UI_SWING) is not None:


### PR DESCRIPTION
Use HA's ClimateEntityFeature.SWING_HORIZONTAL_MODE (flag 512) to expose horizontal airflow direction directly on the climate entity, so climate cards like custom:simple-thermostat can control it without a separate select entity.

Changes:
- Import AIRFLOW_HORIZ and ENL_AIR_HORZ from pychonet
- Add SWING_HORIZONTAL_MODE to supported_features when device has ENL_AIR_HORZ
- Set swing_horizontal_mode/swing_horizontal_modes attributes from device data
- Implement async_set_swing_horizontal_mode() using pychonet setAirflowHoriz()
- Respect user-configured horizontal swing options from config flow
- Guard with hasattr() for backward compatibility with older HA versions
- Units without horizontal swing hardware are unaffected
- Existing select entities are preserved

https://claude.ai/code/session_01NN3TbeMTCoarQwQ7fmzRoS