### PR TITLE
Fix hvac_action stuck on COOLING/HEATING in single-mode cool/heat

### DIFF
--- a/custom_components/echonetlite/climate.py
+++ b/custom_components/echonetlite/climate.py
@@ -237,9 +237,27 @@ class EchonetClimate(ClimateEntity):
         self._attr_hvac_action = HVACAction.OFF
         if self._connector._update_data[ENL_STATUS] == DATA_STATE_ON:
             if self._connector._update_data[ENL_HVAC_MODE] == HVACMode.HEAT:
-                self._attr_hvac_action = HVACAction.HEATING
+                _room_temp = self._connector._update_data.get(ENL_HVAC_ROOM_TEMP)
+                _set_temp = self._connector._update_data.get(ENL_HVAC_SET_TEMP)
+                if (
+                    _room_temp is not None
+                    and _set_temp is not None
+                    and _room_temp >= _set_temp
+                ):
+                    self._attr_hvac_action = HVACAction.IDLE
+                else:
+                    self._attr_hvac_action = HVACAction.HEATING
             elif self._connector._update_data[ENL_HVAC_MODE] == HVACMode.COOL:
-                self._attr_hvac_action = HVACAction.COOLING
+                _room_temp = self._connector._update_data.get(ENL_HVAC_ROOM_TEMP)
+                _set_temp = self._connector._update_data.get(ENL_HVAC_SET_TEMP)
+                if (
+                    _room_temp is not None
+                    and _set_temp is not None
+                    and _room_temp <= _set_temp
+                ):
+                    self._attr_hvac_action = HVACAction.IDLE
+                else:
+                    self._attr_hvac_action = HVACAction.COOLING
             elif self._connector._update_data[ENL_HVAC_MODE] == HVACMode.DRY:
                 self._attr_hvac_action = HVACAction.DRYING
             elif self._connector._update_data[ENL_HVAC_MODE] == HVACMode.FAN_ONLY:


### PR DESCRIPTION
## Issue

In single-mode `cool` or `heat`, `hvac_action` is always set to `COOLING` / `HEATING`
regardless of whether the setpoint has been reached. It never transitions to `IDLE`.

Reproduction:
- Mode: cool
- current_temperature: 24°C
- target_temperature: 25°C
- Reported `hvac_action`: `cooling` (expected: `idle`)

## Fix

Apply the same setpoint-vs-room-temp comparison logic already present for the
`heat_cool` / `auto` mode (`climate.py:247-260`) to the single-mode `cool` and `heat`
branches. No new logic — just internal consistency with the existing dual-mode handling.

## Scope

Not vendor-specific. Affects all devices using the ECHONET Lite `HomeAirConditioner`
(0x0130) class.

## Cross-validation

Validated against the Mitsubishi MELCloud HA integration on the same hardware (both
integrations running in parallel): MELCloud correctly reports `idle` when setpoint
is reached, while ECHONET on the same device kept reporting `cooling`. The patched
behavior matches MELCloud, corroborating that "compare setpoint vs current_temp" is
the correct heuristic.